### PR TITLE
Updated the pagination query params

### DIFF
--- a/lib/cardsApi.ts
+++ b/lib/cardsApi.ts
@@ -97,22 +97,23 @@ function getCardById(cardId: string) {
 
 /**
  * Get Cards
- * @param {String} before
- * @param {String} after
- * @param {Integer} limit
+ * @param {String} pageBefore
+ * @param {String} pageAfter
+ * @param {String} pageSize
  * @param {String} customerId
+ * @param {String} customerRefId
  */
 function getCards(
-  before: string,
-  after: string,
-  limit: string,
+  pageBefore: string,
+  pageAfter: string,
+  pageSize: string,
   customerId: string,
   customerRefId: string
 ) {
   const queryParams = {
-    before,
-    after,
-    limit,
+    pageBefore,
+    pageAfter,
+    pageSize,
     customerId,
     customerRefId
   }

--- a/lib/paymentsApi.ts
+++ b/lib/paymentsApi.ts
@@ -121,21 +121,21 @@ function createPayment(
 
 /**
  * Get payments
- * @param {String} before
- * @param {String} after
- * @param {String} limit
- * @param {String} customerRefId
+ * @param {String} pageBefore
+ * @param {String} pageAfter
+ * @param {String} pageSize
+ * @param {String} customerId
  */
 function getPayments(
-  before: string,
-  after: string,
-  limit: string,
+  pageBefore: string,
+  pageAfter: string,
+  pageSize: string,
   customerId: string
 ) {
   const queryParams = {
-    before,
-    after,
-    limit,
+    pageBefore,
+    pageAfter,
+    pageSize,
     customerId
   }
 


### PR DESCRIPTION
## Problem
The pagination query params once updated will cause breakage in the existing get cards and get payments API.

## Solution
Have updated the pagination query params to have the new param value for before, after and size.

## Testing
The above changes can be tested and merged once the new API changes has been made.
