### PR TITLE
Fix gear icon, fixes #5

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -71,7 +71,7 @@
       <v-toolbar-title v-text="title" />
       <v-spacer />
       <v-btn icon @click.stop="showRightDrawer = !showRightDrawer">
-        <v-icon>mdi-settings</v-icon>
+        <v-icon>mdi-cog</v-icon>
       </v-btn>
     </v-app-bar>
     <v-content>


### PR DESCRIPTION
Replaces material design icon `mdi-settings`, because it is not supported in version 5.0.45 anymore. Also see http://materialdesignicons.com/cdn/5.0.45/