### PR TITLE
Fix refund amount naming for marketplace

### DIFF
--- a/lib/marketplaceApi.ts
+++ b/lib/marketplaceApi.ts
@@ -35,7 +35,7 @@ export interface CreateMarketplacePaymentPayload {
 
 export interface RefundPaymentPayload {
   refId: string
-  refundAmount: {
+  amount: {
     amount: string
     currency: string
   }

--- a/pages/debug/marketplace/payments/refund.vue
+++ b/pages/debug/marketplace/payments/refund.vue
@@ -84,7 +84,7 @@ export default class RefundPaymentClass extends Vue {
 
     const payload: RefundPaymentPayload = {
       refId: this.formData.refId,
-      refundAmount: amountDetail
+      amount: amountDetail
     }
 
     try {


### PR DESCRIPTION
We renamed `refundAmount` here: https://github.com/circlefin/payments-sample-app/pull/11 but merged another PR that still uses the wrong property name.