### PR TITLE
Don't specify phone number in prefill test data

### DIFF
--- a/components/CreateCardForm.vue
+++ b/components/CreateCardForm.vue
@@ -153,7 +153,6 @@ export default class CreateCardFormClass extends Vue {
     line2: '',
     city: '',
     postalCode: '',
-    phone: '',
     email: ''
   }
   rules = {

--- a/lib/cardTestData.ts
+++ b/lib/cardTestData.ts
@@ -15,7 +15,7 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '',
+      phone: '+16171234567',
       email: 'customer-0001@circle.com',
       verificationMethod: 'cvv'
     }
@@ -36,7 +36,7 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '',
+      phone: '+16171234567',
       email: 'customer-0002@circle.com',
       verificationMethod: 'cvv'
     }
@@ -57,7 +57,7 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '',
+      phone: '+16171234567',
       email: 'customer-0003@circle.com',
       verificationMethod: 'cvv'
     }
@@ -78,7 +78,7 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '',
+      phone: '+16171234567',
       email: 'customer-0004@circle.com',
       verificationMethod: 'cvv'
     }
@@ -99,7 +99,7 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '',
+      phone: '+16171234567',
       email: 'customer-0005@circle.com',
       verificationMethod: 'cvv'
     }
@@ -120,7 +120,7 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '',
+      phone: '+16171234567',
       email: 'customer-0006@circle.com',
       verificationMethod: 'cvv'
     }
@@ -141,7 +141,7 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '',
+      phone: '+16171234567',
       email: 'customer-0007@circle.com',
       verificationMethod: 'cvv'
     }

--- a/lib/cardTestData.ts
+++ b/lib/cardTestData.ts
@@ -15,7 +15,6 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '+16171234567',
       email: 'customer-0001@circle.com',
       verificationMethod: 'cvv'
     }
@@ -36,7 +35,6 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '+16171234567',
       email: 'customer-0002@circle.com',
       verificationMethod: 'cvv'
     }
@@ -57,7 +55,6 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '+16171234567',
       email: 'customer-0003@circle.com',
       verificationMethod: 'cvv'
     }
@@ -78,7 +75,6 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '+16171234567',
       email: 'customer-0004@circle.com',
       verificationMethod: 'cvv'
     }
@@ -99,7 +95,6 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '+16171234567',
       email: 'customer-0005@circle.com',
       verificationMethod: 'cvv'
     }
@@ -120,7 +115,6 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '+16171234567',
       email: 'customer-0006@circle.com',
       verificationMethod: 'cvv'
     }
@@ -141,7 +135,6 @@ export const exampleCards = [
       line2: '',
       city: 'Test City',
       postalCode: '11111',
-      phone: '+16171234567',
       email: 'customer-0007@circle.com',
       verificationMethod: 'cvv'
     }

--- a/pages/debug/cards/create.vue
+++ b/pages/debug/cards/create.vue
@@ -143,7 +143,6 @@ export default class CreateCardClass extends Vue {
     line2: '',
     city: '',
     postalCode: '',
-    phone: '',
     verificationMethod: 'cvv',
     email: ''
   }


### PR DESCRIPTION
Fixes prefill data causing an invalid phone format error on the `POST /cards` endpoint