### PR TITLE
Removing the optional fields from the create card flow

### DIFF
--- a/components/CreateCardForm.vue
+++ b/components/CreateCardForm.vue
@@ -72,15 +72,6 @@
               label="Country Code"
               :disabled="loading"
             />
-
-            <v-text-field v-model="formData.phoneNumber" label="Phone" />
-
-            <v-text-field
-              v-model="formData.email"
-              :rules="[rules.required]"
-              label="Email"
-              required
-            />
           </v-expansion-panel-content>
         </v-expansion-panel>
       </v-expansion-panels>
@@ -152,9 +143,7 @@ export default class CreateCardFormClass extends Vue {
     line1: '',
     line2: '',
     city: '',
-    postalCode: '',
-    phoneNumber: '',
-    email: ''
+    postalCode: ''
   }
   rules = {
     isNumber: (v: string) =>
@@ -203,7 +192,7 @@ export default class CreateCardFormClass extends Vue {
   async makeApiCall() {
     this.loading = true
 
-    const { email, phoneNumber, cardNumber, cvv, ...data } = this.formData
+    const { cardNumber, cvv, ...data } = this.formData
     const cardDetails = {
       number: cardNumber.trim().replace(/\D/g, ''),
       cvv
@@ -219,8 +208,6 @@ export default class CreateCardFormClass extends Vue {
       encryptedData: '',
       billingDetails,
       metadata: {
-        email,
-        phoneNumber,
         sessionId: 'xxx',
         ipAddress: '172.33.222.1'
       }

--- a/components/CreateCardForm.vue
+++ b/components/CreateCardForm.vue
@@ -72,6 +72,10 @@
               label="Country Code"
               :disabled="loading"
             />
+
+            <v-text-field v-model="formData.phoneNumber" label="Phone" />
+
+            <v-text-field v-model="formData.email" label="Email" />
           </v-expansion-panel-content>
         </v-expansion-panel>
       </v-expansion-panels>
@@ -143,7 +147,9 @@ export default class CreateCardFormClass extends Vue {
     line1: '',
     line2: '',
     city: '',
-    postalCode: ''
+    postalCode: '',
+    phoneNumber: '',
+    email: ''
   }
   rules = {
     isNumber: (v: string) =>
@@ -192,7 +198,7 @@ export default class CreateCardFormClass extends Vue {
   async makeApiCall() {
     this.loading = true
 
-    const { cardNumber, cvv, ...data } = this.formData
+    const { email, phoneNumber, cardNumber, cvv, ...data } = this.formData
     const cardDetails = {
       number: cardNumber.trim().replace(/\D/g, ''),
       cvv
@@ -208,6 +214,8 @@ export default class CreateCardFormClass extends Vue {
       encryptedData: '',
       billingDetails,
       metadata: {
+        email,
+        phoneNumber,
         sessionId: 'xxx',
         ipAddress: '172.33.222.1'
       }

--- a/lib/cardsApi.ts
+++ b/lib/cardsApi.ts
@@ -4,8 +4,8 @@ import axios from 'axios'
 import { getAPIHostname } from './apiTarget'
 
 interface MetaData {
-  email: string
-  phoneNumber: string
+  email?: string
+  phoneNumber?: string
   sessionId: string
   ipAddress: string
 }

--- a/lib/cardsApi.ts
+++ b/lib/cardsApi.ts
@@ -4,8 +4,8 @@ import axios from 'axios'
 import { getAPIHostname } from './apiTarget'
 
 interface MetaData {
-  email?: string
-  phoneNumber?: string
+  email: string
+  phoneNumber: string
   sessionId: string
   ipAddress: string
 }


### PR DESCRIPTION
The phone number and email fields are optional params in the create card endpoint. So have removed these fields in the create card flow.