### PR TITLE
Add Placeholder fields in the form

### DIFF
--- a/components/CreateCardForm.vue
+++ b/components/CreateCardForm.vue
@@ -33,6 +33,7 @@
               v-model="formData.name"
               :rules="[rules.required]"
               label="Cardholder name"
+              hint="Name must have first and last name"
               required
             />
 
@@ -73,7 +74,11 @@
               :disabled="loading"
             />
 
-            <v-text-field v-model="formData.phoneNumber" label="Phone" />
+            <v-text-field
+              v-model="formData.phoneNumber"
+              hint="Phone Number should be a valid number with the country code"
+              label="Phone"
+            />
 
             <v-text-field v-model="formData.email" label="Email" />
           </v-expansion-panel-content>

--- a/components/CreateCardForm.vue
+++ b/components/CreateCardForm.vue
@@ -64,6 +64,7 @@
               v-model="formData.district"
               :rules="[rules.required]"
               label="District"
+              hint="District must be a 2 letter code for US states"
               required
             />
 

--- a/components/CreateCardForm.vue
+++ b/components/CreateCardForm.vue
@@ -33,7 +33,7 @@
               v-model="formData.name"
               :rules="[rules.required]"
               label="Cardholder name"
-              hint="Name must have first and last name"
+              hint="Full name of the card holder"
               required
             />
 
@@ -64,7 +64,7 @@
               v-model="formData.district"
               :rules="[rules.required]"
               label="District"
-              hint="District must be a 2 letter code for US states"
+              hint="State / County / Province / Region portion of the address. US and Canada use the two-letter code for the subdivision"
               required
             />
 
@@ -77,7 +77,7 @@
 
             <v-text-field
               v-model="formData.phoneNumber"
-              hint="Phone Number should be a valid number with the country code"
+              hint="Phone number of the user in E.164 format"
               label="Phone"
             />
 

--- a/pages/debug/cards/create.vue
+++ b/pages/debug/cards/create.vue
@@ -49,7 +49,7 @@
 
           <v-text-field
             v-model="formData.name"
-            hint="Name must have first and last name"
+            hint="Full name of the card holder"
             label="Full name"
           />
 
@@ -64,14 +64,14 @@
           <v-text-field
             v-model="formData.district"
             label="District"
-            hint="District must be a 2 letter code for US states"
+            hint="State / County / Province / Region portion of the address. US and Canada use the two-letter code for the subdivision"
           />
 
           <v-text-field v-model="formData.country" label="Country Code" />
 
           <v-text-field
             v-model="formData.phoneNumber"
-            hint="Phone Number should be a valid number with the country code"
+            hint="Phone number of the user in E.164 format"
             label="Phone"
           />
 

--- a/pages/debug/cards/create.vue
+++ b/pages/debug/cards/create.vue
@@ -47,7 +47,11 @@
 
           <v-text-field v-model="formData.expiry.year" label="Expiry Year" />
 
-          <v-text-field v-model="formData.name" label="Full name" />
+          <v-text-field
+            v-model="formData.name"
+            hint="Name must have first and last name"
+            label="Full name"
+          />
 
           <v-text-field v-model="formData.line1" label="Address Line 1" />
 
@@ -61,7 +65,11 @@
 
           <v-text-field v-model="formData.country" label="Country Code" />
 
-          <v-text-field v-model="formData.phoneNumber" label="Phone" />
+          <v-text-field
+            v-model="formData.phoneNumber"
+            hint="Phone Number should be a valid number with the country code"
+            label="Phone"
+          />
 
           <v-text-field v-model="formData.email" label="Email" />
 

--- a/pages/debug/cards/create.vue
+++ b/pages/debug/cards/create.vue
@@ -61,7 +61,11 @@
 
           <v-text-field v-model="formData.city" label="City" />
 
-          <v-text-field v-model="formData.district" label="District" />
+          <v-text-field
+            v-model="formData.district"
+            label="District"
+            hint="District must be a 2 letter code for US states"
+          />
 
           <v-text-field v-model="formData.country" label="Country Code" />
 

--- a/pages/debug/cards/update.vue
+++ b/pages/debug/cards/update.vue
@@ -13,7 +13,11 @@
 
           <v-text-field v-model="formData.expiry.year" label="Expiry Year" />
 
-          <v-text-field v-model="formData.name" label="Full Name" />
+          <v-text-field
+            v-model="formData.name"
+            hint="Name must have first and last name"
+            label="Full Name"
+          />
 
           <v-text-field v-model="formData.line1" label="Address Line 1" />
 
@@ -27,7 +31,11 @@
 
           <v-text-field v-model="formData.country" label="Country Code" />
 
-          <v-text-field v-model="formData.phoneNumber" label="Phone" />
+          <v-text-field
+            v-model="formData.phoneNumber"
+            hint="Phone Number should be a valid number with the country code"
+            label="Phone"
+          />
 
           <v-text-field v-model="formData.email" label="Email" />
           <v-btn

--- a/pages/debug/cards/update.vue
+++ b/pages/debug/cards/update.vue
@@ -27,7 +27,11 @@
 
           <v-text-field v-model="formData.city" label="City" />
 
-          <v-text-field v-model="formData.district" label="District" />
+          <v-text-field
+            v-model="formData.district"
+            label="District"
+            hint="District must be a 2 letter code for US states"
+          />
 
           <v-text-field v-model="formData.country" label="Country Code" />
 

--- a/pages/debug/cards/update.vue
+++ b/pages/debug/cards/update.vue
@@ -15,7 +15,7 @@
 
           <v-text-field
             v-model="formData.name"
-            hint="Name must have first and last name"
+            hint="Full name of the card holder"
             label="Full Name"
           />
 
@@ -30,14 +30,14 @@
           <v-text-field
             v-model="formData.district"
             label="District"
-            hint="District must be a 2 letter code for US states"
+            hint="State / County / Province / Region portion of the address. US and Canada use the two-letter code for the subdivision"
           />
 
           <v-text-field v-model="formData.country" label="Country Code" />
 
           <v-text-field
             v-model="formData.phoneNumber"
-            hint="Phone Number should be a valid number with the country code"
+            hint="Phone number of the user in E.164 format"
             label="Phone"
           />
 

--- a/pages/debug/marketplace/payments/create.vue
+++ b/pages/debug/marketplace/payments/create.vue
@@ -23,7 +23,11 @@
 
           <v-text-field v-if="cvvRequired" v-model="formData.cvv" label="CVV" />
 
-          <v-text-field v-model="formData.phoneNumber" label="Phone" />
+          <v-text-field
+            v-model="formData.phoneNumber"
+            hint="Phone Number should be a valid number with the country code"
+            label="Phone"
+          />
 
           <v-text-field v-model="formData.email" label="Email" />
 

--- a/pages/debug/marketplace/payments/create.vue
+++ b/pages/debug/marketplace/payments/create.vue
@@ -25,7 +25,7 @@
 
           <v-text-field
             v-model="formData.phoneNumber"
-            hint="Phone Number should be a valid number with the country code"
+            hint="Phone number of the user in E.164 format"
             label="Phone"
           />
 

--- a/pages/debug/payments/create.vue
+++ b/pages/debug/payments/create.vue
@@ -18,7 +18,11 @@
 
           <v-text-field v-if="cvvRequired" v-model="formData.cvv" label="CVV" />
 
-          <v-text-field v-model="formData.phoneNumber" label="Phone" />
+          <v-text-field
+            v-model="formData.phoneNumber"
+            hint="Phone Number should be a valid number with the country code"
+            label="Phone"
+          />
 
           <v-text-field v-model="formData.email" label="Email" />
 

--- a/pages/debug/payments/create.vue
+++ b/pages/debug/payments/create.vue
@@ -20,7 +20,7 @@
 
           <v-text-field
             v-model="formData.phoneNumber"
-            hint="Phone Number should be a valid number with the country code"
+            hint="Phone number of the user in E.164 format"
             label="Phone"
           />
 

--- a/pages/flow/charge/existing-card/index.vue
+++ b/pages/flow/charge/existing-card/index.vue
@@ -49,7 +49,7 @@
 
               <v-text-field
                 v-model="formData.phoneNumber"
-                hint="Phone Number should be a valid number with the country code"
+                hint="Phone number of the user in E.164 format"
                 label="Phone"
                 :disabled="loading"
               />

--- a/pages/flow/charge/existing-card/index.vue
+++ b/pages/flow/charge/existing-card/index.vue
@@ -49,6 +49,7 @@
 
               <v-text-field
                 v-model="formData.phoneNumber"
+                hint="Phone Number should be a valid number with the country code"
                 label="Phone"
                 :disabled="loading"
               />

--- a/pages/flow/charge/index.vue
+++ b/pages/flow/charge/index.vue
@@ -78,6 +78,7 @@
               <v-text-field
                 v-model="formData.cardData.name"
                 :rules="[rules.required]"
+                hint="Name must have first and last name"
                 label="Cardholder name"
                 :disabled="loading"
               />
@@ -124,6 +125,7 @@
 
               <v-text-field
                 v-model="formData.cardData.phoneNumber"
+                hint="Phone Number should be a valid number with the country code"
                 label="Phone"
                 :disabled="loading"
               />

--- a/pages/flow/charge/index.vue
+++ b/pages/flow/charge/index.vue
@@ -78,7 +78,7 @@
               <v-text-field
                 v-model="formData.cardData.name"
                 :rules="[rules.required]"
-                hint="Name must have first and last name"
+                hint="Full name of the card holder"
                 label="Cardholder name"
                 :disabled="loading"
               />
@@ -114,7 +114,7 @@
                 :rules="[rules.required]"
                 label="District"
                 :disabled="loading"
-                hint="District must be a 2 letter code for US states"
+                hint="State / County / Province / Region portion of the address. US and Canada use the two-letter code for the subdivision"
               />
 
               <CountrySelect
@@ -126,7 +126,7 @@
 
               <v-text-field
                 v-model="formData.cardData.phoneNumber"
-                hint="Phone Number should be a valid number with the country code"
+                hint="Phone number of the user in E.164 format"
                 label="Phone"
                 :disabled="loading"
               />

--- a/pages/flow/charge/index.vue
+++ b/pages/flow/charge/index.vue
@@ -114,6 +114,7 @@
                 :rules="[rules.required]"
                 label="District"
                 :disabled="loading"
+                hint="District must be a 2 letter code for US states"
               />
 
               <CountrySelect


### PR DESCRIPTION
The form fields doesn't have any placeholder or hints that will help customers to determine the type of input that must be provided in the field. 
Have added hints to the fields that require additional information.