### PR TITLE
Adding reason for cancel and refund payment

### DIFF
--- a/lib/marketplaceApi.ts
+++ b/lib/marketplaceApi.ts
@@ -40,6 +40,7 @@ export interface RefundPaymentPayload {
     amount: string
     currency: string
   }
+  reason: string | undefined
 }
 
 export interface CreateWallet {
@@ -149,6 +150,7 @@ function getPaymentById(id: string) {
  */
 function refundPayment(id: string, payload: RefundPaymentPayload) {
   const url = `/v1/payments/${id}/refund/`
+  payload.reason = nullIfEmpty(payload.reason)
   return instance.post(url, payload)
 }
 

--- a/lib/paymentsApi.ts
+++ b/lib/paymentsApi.ts
@@ -32,7 +32,7 @@ export interface RefundPaymentPayload {
     amount: string
     currency: string
   }
-  reason: string
+  reason: string | undefined
 }
 
 const instance = axios.create({
@@ -152,6 +152,7 @@ function getPaymentById(id: string) {
  */
 function refundPayment(id: string, payload: RefundPaymentPayload) {
   const url = `/v1/payments/${id}/refund`
+  payload.reason = nullIfEmpty(payload.reason)
   return instance.post(url, payload)
 }
 

--- a/lib/paymentsApi.ts
+++ b/lib/paymentsApi.ts
@@ -32,6 +32,7 @@ export interface RefundPaymentPayload {
     amount: string
     currency: string
   }
+  reason: string
 }
 
 const instance = axios.create({

--- a/pages/debug/marketplace/payments/cancel.vue
+++ b/pages/debug/marketplace/payments/cancel.vue
@@ -8,6 +8,11 @@
             v-model="formData.idempotencyKey"
             label="Idempotency Key"
           />
+          <v-select
+            v-model="formData.reason"
+            :items="reasonsList"
+            label="Reason"
+          />
           <v-btn
             depressed
             class="mb-7"
@@ -58,8 +63,10 @@ export default class CancelPaymentClass extends Vue {
   // data
   formData = {
     paymentId: '',
-    idempotencyKey: ''
+    idempotencyKey: '',
+    reason: ''
   }
+  reasonsList = ['duplicate', 'fraudulent', 'requested_by_customer']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false
@@ -75,7 +82,8 @@ export default class CancelPaymentClass extends Vue {
     this.loading = true
 
     const payload = {
-      idempotencyKey: this.formData.idempotencyKey
+      idempotencyKey: this.formData.idempotencyKey,
+      reason: this.formData.reason
     }
 
     try {

--- a/pages/debug/marketplace/payments/cancel.vue
+++ b/pages/debug/marketplace/payments/cancel.vue
@@ -66,7 +66,7 @@ export default class CancelPaymentClass extends Vue {
     idempotencyKey: '',
     reason: ''
   }
-  reasonsList = ['duplicate', 'fraudulent', 'requested_by_customer']
+  reasonsList = ['', 'duplicate', 'fraudulent', 'requested_by_customer']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false

--- a/pages/debug/marketplace/payments/refund.vue
+++ b/pages/debug/marketplace/payments/refund.vue
@@ -12,6 +12,12 @@
 
           <v-text-field v-model="formData.amount" label="Amount" />
 
+          <v-select
+            v-model="formData.reason"
+            :items="reasonsList"
+            label="Reason"
+          />
+
           <v-btn
             depressed
             class="mb-7"
@@ -64,8 +70,10 @@ export default class RefundPaymentClass extends Vue {
   formData = {
     paymentId: '',
     idempotencyKey: '',
-    amount: '0.00'
+    amount: '0.00',
+    reason: ''
   }
+  reasonsList = ['duplicate', 'fraudulent', 'requested_by_customer']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false
@@ -87,7 +95,8 @@ export default class RefundPaymentClass extends Vue {
 
     const payload: RefundPaymentPayload = {
       idempotencyKey: this.formData.idempotencyKey,
-      amount: amountDetail
+      amount: amountDetail,
+      reason: this.formData.reason
     }
 
     try {

--- a/pages/debug/marketplace/payments/refund.vue
+++ b/pages/debug/marketplace/payments/refund.vue
@@ -73,7 +73,7 @@ export default class RefundPaymentClass extends Vue {
     amount: '0.00',
     reason: ''
   }
-  reasonsList = ['duplicate', 'fraudulent', 'requested_by_customer']
+  reasonsList = ['', 'duplicate', 'fraudulent', 'requested_by_customer']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false

--- a/pages/debug/payments/cancel.vue
+++ b/pages/debug/payments/cancel.vue
@@ -8,6 +8,11 @@
             v-model="formData.idempotencyKey"
             label="Idempotency Key"
           />
+          <v-select
+            v-model="formData.reason"
+            :items="reasonsList"
+            label="Reason"
+          />
           <v-btn
             depressed
             class="mb-7"
@@ -58,8 +63,10 @@ export default class CancelPaymentClass extends Vue {
   // data
   formData = {
     paymentId: '',
-    idempotencyKey: ''
+    idempotencyKey: '',
+    reason: ''
   }
+  reasonsList = ['duplicate', 'fraudulent', 'requested_by_customer']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false
@@ -75,7 +82,8 @@ export default class CancelPaymentClass extends Vue {
     this.loading = true
 
     const payload = {
-      idempotencyKey: this.formData.idempotencyKey
+      idempotencyKey: this.formData.idempotencyKey,
+      reason: this.formData.reason
     }
 
     try {

--- a/pages/debug/payments/cancel.vue
+++ b/pages/debug/payments/cancel.vue
@@ -66,7 +66,7 @@ export default class CancelPaymentClass extends Vue {
     idempotencyKey: '',
     reason: ''
   }
-  reasonsList = ['duplicate', 'fraudulent', 'requested_by_customer']
+  reasonsList = ['', 'duplicate', 'fraudulent', 'requested_by_customer']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false

--- a/pages/debug/payments/refund.vue
+++ b/pages/debug/payments/refund.vue
@@ -12,6 +12,12 @@
 
           <v-text-field v-model="formData.amount" label="Amount" />
 
+          <v-select
+            v-model="formData.reason"
+            :items="reasonsList"
+            label="Reason"
+          />
+
           <v-btn
             depressed
             class="mb-7"
@@ -64,8 +70,10 @@ export default class RefundPaymentClass extends Vue {
   formData = {
     paymentId: '',
     idempotencyKey: '',
-    amount: '0.00'
+    amount: '0.00',
+    reason: ''
   }
+  reasonsList = ['duplicate', 'fraudulent', 'requested_by_customer']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false
@@ -87,7 +95,8 @@ export default class RefundPaymentClass extends Vue {
 
     const payload: RefundPaymentPayload = {
       idempotencyKey: this.formData.idempotencyKey,
-      amount: amountDetail
+      amount: amountDetail,
+      reason: this.formData.reason
     }
 
     try {

--- a/pages/debug/payments/refund.vue
+++ b/pages/debug/payments/refund.vue
@@ -73,7 +73,7 @@ export default class RefundPaymentClass extends Vue {
     amount: '0.00',
     reason: ''
   }
-  reasonsList = ['duplicate', 'fraudulent', 'requested_by_customer']
+  reasonsList = ['', 'duplicate', 'fraudulent', 'requested_by_customer']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false


### PR DESCRIPTION
Do Not Merge Until the API has been updated

The refund and cancel now requires a reason stating why the payment was refunded or cancelled. Adding this param to both payments and marketplace APIs
<img width="1680" alt="Screen Shot 2020-06-10 at 5 19 42 PM" src="https://user-images.githubusercontent.com/59667730/84319898-cafb2480-ab3e-11ea-8488-3282060de2fa.png">
