### PR TITLE
Adding wallets filter in fetch transfers API

### DIFF
--- a/lib/transfersApi.ts
+++ b/lib/transfersApi.ts
@@ -85,6 +85,7 @@ function getTransferById(transferId: string) {
  * @param {String} pageSize
  */
 function getTransfers(
+  walletId: string,
   sourceWalletId: string,
   destinationWalletId: string,
   from: string,
@@ -94,6 +95,7 @@ function getTransfers(
   pageSize: string
 ) {
   const queryParams = {
+    walletId: nullIfEmpty(walletId),
     sourceWalletId: nullIfEmpty(sourceWalletId),
     destinationWalletId: nullIfEmpty(destinationWalletId),
     from: nullIfEmpty(from),

--- a/pages/debug/wallets/transfers/fetch.vue
+++ b/pages/debug/wallets/transfers/fetch.vue
@@ -4,6 +4,7 @@
       <v-col cols="12" md="4">
         <v-form>
           <header>Optional filter params:</header>
+          <v-text-field v-model="formData.walletId" label="Wallet ID" />
           <v-text-field
             v-model="formData.sourceWalletId"
             label="Source Wallet ID"
@@ -65,6 +66,7 @@ import ErrorSheet from '@/components/ErrorSheet.vue'
 export default class FetchTransfersClass extends Vue {
   // data
   formData = {
+    walletId: '',
     sourceWalletId: '',
     destinationWalletId: '',
     from: '',
@@ -92,6 +94,7 @@ export default class FetchTransfersClass extends Vue {
     this.loading = true
     try {
       await this.$transfersApi.getTransfers(
+        this.formData.walletId,
         this.formData.sourceWalletId,
         this.formData.destinationWalletId,
         this.formData.from,


### PR DESCRIPTION
The fetch transfers API not supports filtering by walletId. Adding this param in the fetch Transfers API