### PR TITLE
Don't add props to the payload if empty

### DIFF
--- a/lib/cardsApi.ts
+++ b/lib/cardsApi.ts
@@ -127,9 +127,9 @@ function getCards(pageBefore: string, pageAfter: string, pageSize: string) {
  */
 function createCard(payload: CreateCardPayload) {
   const url = `/v1/cards`
-  if (payload.metadata) {
-    payload.metadata.email = nullIfEmpty(payload.metadata.email)
-    payload.metadata.phoneNumber = nullIfEmpty(payload.metadata.phoneNumber)
+  // phoneNumber is optional, don't include in the payload when empty
+  if (payload.metadata && !nullIfEmpty(payload.metadata.phoneNumber)) {
+    delete payload.metadata.phoneNumber
   }
   return instance.post(url, payload)
 }
@@ -142,9 +142,9 @@ function createCard(payload: CreateCardPayload) {
  */
 function updateCard(cardId: string, payload: UpdateCardPayload) {
   const url = `/v1/cards/${cardId}`
-  if (payload.metadata) {
-    payload.metadata.email = nullIfEmpty(payload.metadata.email)
-    payload.metadata.phoneNumber = nullIfEmpty(payload.metadata.phoneNumber)
+  // phoneNumber is optional, don't include in the payload when empty
+  if (payload.metadata && !nullIfEmpty(payload.metadata.phoneNumber)) {
+    delete payload.metadata.phoneNumber
   }
   return instance.put(url, payload)
 }

--- a/lib/marketplaceApi.ts
+++ b/lib/marketplaceApi.ts
@@ -89,8 +89,9 @@ function getInstance() {
  */
 function createPayment(payload: CreateMarketplacePaymentPayload) {
   const url = `/v1/marketplace/payments`
-  if (payload.metadata) {
-    payload.metadata.phoneNumber = nullIfEmpty(payload.metadata.phoneNumber)
+  // phoneNumber is optional, don't include in the payload when empty
+  if (payload.metadata && !nullIfEmpty(payload.metadata.phoneNumber)) {
+    delete payload.metadata.phoneNumber
   }
   return instance.post(url, payload)
 }

--- a/lib/paymentsApi.ts
+++ b/lib/paymentsApi.ts
@@ -98,8 +98,9 @@ function cancelPayment(id: string, payload: any) {
  */
 function createPayment(payload: CreatePaymentPayload) {
   const url = `/v1/payments`
-  if (payload.metadata) {
-    payload.metadata.phoneNumber = nullIfEmpty(payload.metadata.phoneNumber)
+  // phoneNumber is optional, don't include in the payload when empty
+  if (payload.metadata && !nullIfEmpty(payload.metadata.phoneNumber)) {
+    delete payload.metadata.phoneNumber
   }
   return instance.post(url, payload)
 }

--- a/lib/walletsApi.ts
+++ b/lib/walletsApi.ts
@@ -83,12 +83,13 @@ function getWallets(
  * @param {String} idempotencyKey
  * @param {String} description
  */
-function createWallet(idempotencyKey: string, description: string) {
+function createWallet(idempotencyKey: string, description?: string) {
   const url = `/v1/wallets`
   const payload = {
     idempotencyKey,
-    description: nullIfEmpty(description)
+    ...(nullIfEmpty(description) && { description })
   }
+
   return instance.post(url, payload)
 }
 


### PR DESCRIPTION
If optional properties are empty we still send that prop in the payload as `prop: undefined`. We should rather not include it.
Fix the places where we have optional properties.

<img width="418" alt="Screen Shot 2020-06-12 at 16 17 05" src="https://user-images.githubusercontent.com/60018266/84512539-71266600-acc8-11ea-846a-cfe6cad32456.png">
