### PR TITLE
[Untracked] Add walletId & remove beneficiaryName to wire creation page

### DIFF
--- a/lib/wiresApi.ts
+++ b/lib/wiresApi.ts
@@ -5,7 +5,7 @@ import { getAPIHostname } from './apiTarget'
 
 export interface CreateWireAccountPayload {
   idempotencyKey: string
-  beneficiaryName: string
+  walletId: string
   accountNumber?: string
   routingNumber?: string
   iban?: string

--- a/lib/wiresTestData.ts
+++ b/lib/wiresTestData.ts
@@ -2,7 +2,7 @@ export const exampleWireAccounts = [
   {
     title: 'US Bank Account',
     formData: {
-      beneficiaryName: 'Satoshi Nakamoto',
+      walletId: null as any,
       accountNumber: '11111111111',
       routingNumber: '121000248',
       iban: '',
@@ -29,7 +29,7 @@ export const exampleWireAccounts = [
   {
     title: 'German Bank Account',
     formData: {
-      beneficiaryName: 'Satoshi Nakamoto',
+      walletId: null as any,
       accountNumber: '',
       routingNumber: '',
       iban: 'DE31100400480532013000',
@@ -56,7 +56,7 @@ export const exampleWireAccounts = [
   {
     title: 'Mexican Bank Account',
     formData: {
-      beneficiaryName: 'Satoshi Nakamoto',
+      walletId: null as any,
       accountNumber: '002010077777777771',
       routingNumber: 'BDEMMXMF',
       iban: '',

--- a/pages/debug/wires/create.vue
+++ b/pages/debug/wires/create.vue
@@ -29,8 +29,10 @@
 
         <v-form>
           <v-text-field
-            v-model="formData.beneficiaryName"
-            label="Beneficiary Name"
+            v-model="formData.walletId"
+            label="Wallet Id"
+            :rules="[rules.isNumber, rules.required]"
+            hint="Unique identifier of the wallet that you wish to wire the funds to. "
           />
 
           <v-text-field
@@ -173,7 +175,7 @@ import ErrorSheet from '@/components/ErrorSheet.vue'
 export default class CreateCardClass extends Vue {
   // data
   formData = {
-    beneficiaryName: '',
+    walletId: '',
     accountNumber: '',
     routingNumber: '',
     iban: '',
@@ -225,7 +227,7 @@ export default class CreateCardClass extends Vue {
   async makeApiCall() {
     this.loading = true
     const {
-      beneficiaryName,
+      walletId,
       accountNumber,
       routingNumber,
       iban,
@@ -235,7 +237,7 @@ export default class CreateCardClass extends Vue {
 
     const payload: CreateWireAccountPayload = {
       idempotencyKey: uuidv4(),
-      beneficiaryName,
+      walletId,
       accountNumber,
       routingNumber,
       iban,


### PR DESCRIPTION
- `WalletId` will be a necessary field once we merge in the support for push payment wire linking. This will be used to support where the end-user/merchant want to deposit their money to.
- Remove the `beneficiaryName` field. 

Result Page should look like this:
<img width="2352" alt="Screen Shot 2020-09-18 at 1 51 05 PM" src="https://user-images.githubusercontent.com/52761714/93629534-788b9880-f9b6-11ea-9b61-44cb681d7370.png">
