### PR TITLE
Expose wire instructions for payments/marketplace API

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -239,6 +239,10 @@ export default class DefaultLayoutsClass extends Vue {
       to: '/debug/wires/details',
     },
     {
+      title: 'GET /wires/{id}/instructions',
+      to: '/debug/wires/instructions',
+    },
+    {
       title: 'POST /wires',
       to: '/debug/wires/create',
     },
@@ -316,6 +320,10 @@ export default class DefaultLayoutsClass extends Vue {
     {
       title: 'GET /wires/{id}',
       to: '/debug/wires/details',
+    },
+    {
+      title: 'GET /wires/{id}/instructions',
+      to: '/debug/wires/instructions',
     },
     {
       title: 'POST /wires',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -235,16 +235,16 @@ export default class DefaultLayoutsClass extends Vue {
       to: '/debug/settlements/details',
     },
     {
+      title: 'POST /wires',
+      to: '/debug/wires/create',
+    },
+    {
       title: 'GET /wires/{id}',
       to: '/debug/wires/details',
     },
     {
       title: 'GET /wires/{id}/instructions',
       to: '/debug/wires/instructions',
-    },
-    {
-      title: 'POST /wires',
-      to: '/debug/wires/create',
     },
     {
       title: 'GET /payouts',
@@ -318,16 +318,16 @@ export default class DefaultLayoutsClass extends Vue {
       to: '/debug/settlements/details',
     },
     {
+      title: 'POST /wires',
+      to: '/debug/wires/create',
+    },
+    {
       title: 'GET /wires/{id}',
       to: '/debug/wires/details',
     },
     {
       title: 'GET /wires/{id}/instructions',
       to: '/debug/wires/instructions',
-    },
-    {
-      title: 'POST /wires',
-      to: '/debug/wires/create',
     },
     {
       title: 'GET /payouts',

--- a/lib/wiresApi.ts
+++ b/lib/wiresApi.ts
@@ -94,8 +94,19 @@ function getWireAccountById(accountId: string) {
   return instance.get(url)
 }
 
+/**
+ * Get Wire Account Instructions
+ * @param {String} accountId
+ */
+function getWireAccountInstructions(accountId: string) {
+  const url = `/v1/banks/wires/${accountId}/instructions`
+
+  return instance.get(url)
+}
+
 export default {
   getInstance,
   createWireAccount,
   getWireAccountById,
+  getWireAccountInstructions,
 }

--- a/pages/debug/index.vue
+++ b/pages/debug/index.vue
@@ -167,6 +167,12 @@
           Api endpoints to manage wire accounts.
         </p>
         <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/wires/create">
+            Create wire account
+          </a>
+        </p>
+        <p>
           <v-chip small color="primary">GET</v-chip>
           <a href="/debug/wires/details">
             Get wire account details by id
@@ -176,12 +182,6 @@
           <v-chip small color="primary">GET</v-chip>
           <a href="/debug/wires/instructions">
             Get wire account instructions by id
-          </a>
-        </p>
-        <p>
-          <v-chip small color="primary warning">POST</v-chip>
-          <a href="/debug/wires/create">
-            Create wire account
           </a>
         </p>
       </v-card>

--- a/pages/debug/index.vue
+++ b/pages/debug/index.vue
@@ -173,6 +173,12 @@
           </a>
         </p>
         <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/wires/instructions">
+            Get wire account instructions by id
+          </a>
+        </p>
+        <p>
           <v-chip small color="primary warning">POST</v-chip>
           <a href="/debug/wires/create">
             Create wire account

--- a/pages/debug/wires/instructions.vue
+++ b/pages/debug/wires/instructions.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.accountId" label="Account Id" />
+          <v-btn
+            depressed
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+    }),
+  },
+})
+export default class FetchAccountInstructionsClass extends Vue {
+  // data
+  formData = {
+    accountId: '',
+  }
+
+  required = [(v: string) => !!v || 'Field is required']
+  error = {}
+  loading = false
+  showError = false
+
+  // methods
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  async makeApiCall() {
+    this.loading = true
+
+    try {
+      await this.$wiresApi.getWireAccountInstructions(this.formData.accountId)
+    } catch (error) {
+      this.error = error
+      this.showError = true
+    } finally {
+      this.loading = false
+    }
+  }
+}
+</script>

--- a/plugins/wiresApi.ts
+++ b/plugins/wiresApi.ts
@@ -5,6 +5,7 @@ declare module 'vue/types/vue' {
     $wiresApi: {
       createWireAccount: (payload: CreateWireAccountPayload) => any
       getWireAccountById: any
+      getWireAccountInstructions: any
       getInstance: any
     }
   }


### PR DESCRIPTION
A new endpoint is added for acquiring wire instructions for a bank account (`GET /wires/{id}/instructions`).