### PR TITLE
implement pagination for fetching recipient addresses

### DIFF
--- a/lib/businessAccount/addressesApi.ts
+++ b/lib/businessAccount/addressesApi.ts
@@ -41,6 +41,13 @@ instance.interceptors.response.use(
   }
 )
 
+const nullIfEmpty = (prop: string | undefined) => {
+  if (prop === '') {
+    return undefined
+  }
+  return prop
+}
+
 /** Returns the axios instance */
 function getInstance() {
   return instance
@@ -57,12 +64,6 @@ function createDepositAddress(payload: CreateDepositAddressPayload) {
 
 /**
  * Get deposit addresses
- * @param {String} walletId
- * @param {String} from
- * @param {String} to
- * @param {String} pageBefore
- * @param {String} pageAfter
- * @param {String} pageSize
  */
 function getDepositAddresses() {
   const url = '/v1/businessAccount/wallets/addresses/deposit'
@@ -81,11 +82,29 @@ function createRecipientAddress(payload: CreateRecipientAddressPayload) {
 
 /**
  * Get deposit addresses
+ * @param {String} from
+ * @param {String} to
+ * @param {String} pageBefore
+ * @param {String} pageAfter
+ * @param {String} pageSize
  */
-function getRecipientAddresses() {
+function getRecipientAddresses(
+  from: string,
+  to: string,
+  pageBefore: string,
+  pageAfter: string,
+  pageSize: string
+) {
+  const queryParams = {
+    from: nullIfEmpty(from),
+    to: nullIfEmpty(to),
+    pageBefore: nullIfEmpty(pageBefore),
+    pageAfter: nullIfEmpty(pageAfter),
+    pageSize: nullIfEmpty(pageSize),
+  }
   const url = '/v1/businessAccount/wallets/addresses/recipient'
 
-  return instance.get(url)
+  return instance.get(url, { params: queryParams })
 }
 
 export default {

--- a/pages/debug/businessAccount/addresses/recipient/fetch.vue
+++ b/pages/debug/businessAccount/addresses/recipient/fetch.vue
@@ -3,6 +3,12 @@
     <v-row>
       <v-col cols="12" md="4">
         <v-form>
+          <header>Optional filter params:</header>
+          <v-text-field v-model="formData.from" label="From" />
+          <v-text-field v-model="formData.to" label="To" />
+          <v-text-field v-model="formData.pageSize" label="PageSize" />
+          <v-text-field v-model="formData.pageBefore" label="PageBefore" />
+          <v-text-field v-model="formData.pageAfter" label="PageAfter" />
           <v-btn
             depressed
             class="mb-7"
@@ -49,6 +55,15 @@ import ErrorSheet from '@/components/ErrorSheet.vue'
   },
 })
 export default class FetchRecipientAddressesClass extends Vue {
+  // data
+  formData = {
+    from: '',
+    to: '',
+    pageSize: '',
+    pageBefore: '',
+    pageAfter: '',
+  }
+
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false
@@ -62,7 +77,13 @@ export default class FetchRecipientAddressesClass extends Vue {
   async makeApiCall() {
     this.loading = true
     try {
-      await this.$businessAccountAddressesApi.getRecipientAddresses()
+      await this.$businessAccountAddressesApi.getRecipientAddresses(
+        this.formData.from,
+        this.formData.to,
+        this.formData.pageBefore,
+        this.formData.pageAfter,
+        this.formData.pageSize
+      )
     } catch (error) {
       this.error = error
       this.showError = true


### PR DESCRIPTION
The endpoint `GET /businessAccount/wallets/addresses/recipient` doesn't has pagination implemented - there could be instances where a customer can have plenty of recipient addresses.