### PR TITLE
Add ALGO to supported chains

### DIFF
--- a/components/ChainSelect.vue
+++ b/components/ChainSelect.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-select
+    :value="value"
+    :items="items"
+    :label="label"
+    :rules="rules"
+    :disabled="disabled"
+    validate-on-blur
+    @input="onInput"
+  ></v-select>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator'
+import chains from '@/lib/chains.json'
+
+@Component({})
+export default class ChainSelect extends Vue {
+  @Prop({ type: String }) value!: string
+  @Prop({ type: String, default: 'Chain' }) label!: string
+  @Prop({ type: Boolean, default: false }) disabled!: boolean
+  @Prop({ type: Array, default: false }) rules!: Array<Function>
+
+  items = chains
+
+  onInput(value: string) {
+    this.$emit('input', value)
+  }
+}
+</script>

--- a/lib/chains.json
+++ b/lib/chains.json
@@ -1,0 +1,4 @@
+[
+  { "value": "ETH", "text": "ETH" },
+  { "value": "ALGO", "text": "ALGO" }
+]

--- a/pages/debug/businessAccount/addresses/deposit/create.vue
+++ b/pages/debug/businessAccount/addresses/deposit/create.vue
@@ -9,10 +9,11 @@
             label="Currency"
           />
 
-          <v-select
+          <ChainSelect
             v-model="formData.chain"
-            :items="blockChains"
+            :rules="[rules.required]"
             label="Chain"
+            :disabled="loading"
           />
 
           <v-btn
@@ -49,10 +50,12 @@ import { v4 as uuidv4 } from 'uuid'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
 import { CreateDepositAddressPayload } from '@/lib/businessAccount/addressesApi'
+import ChainSelect from '@/components/ChainSelect.vue'
 @Component({
   components: {
     RequestInfo,
     ErrorSheet,
+    ChainSelect,
   },
   computed: {
     ...mapGetters({
@@ -68,9 +71,11 @@ export default class CreateDepositAddressClass extends Vue {
     chain: '',
   }
 
+  rules = {
+    required: (v: string) => !!v || 'Field is required',
+  }
+
   currencyTypes = ['USD']
-  blockChains = ['ETH', 'ALGO']
-  required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false
   showError = false

--- a/pages/debug/businessAccount/addresses/deposit/create.vue
+++ b/pages/debug/businessAccount/addresses/deposit/create.vue
@@ -11,7 +11,6 @@
 
           <ChainSelect
             v-model="formData.chain"
-            :rules="[rules.required]"
             label="Chain"
             :disabled="loading"
           />
@@ -69,10 +68,6 @@ export default class CreateDepositAddressClass extends Vue {
   formData = {
     currency: '',
     chain: '',
-  }
-
-  rules = {
-    required: (v: string) => !!v || 'Field is required',
   }
 
   currencyTypes = ['USD']

--- a/pages/debug/businessAccount/addresses/deposit/create.vue
+++ b/pages/debug/businessAccount/addresses/deposit/create.vue
@@ -3,9 +3,17 @@
     <v-row>
       <v-col cols="12" md="4">
         <v-form>
-          <v-text-field v-model="formData.currency" label="Currency" />
+          <v-select
+            v-model="formData.currency"
+            :items="currencyTypes"
+            label="Currency"
+          />
 
-          <v-text-field v-model="formData.chain" label="Chain" />
+          <v-select
+            v-model="formData.chain"
+            :items="blockChains"
+            label="Chain"
+          />
 
           <v-btn
             depressed
@@ -60,6 +68,8 @@ export default class CreateDepositAddressClass extends Vue {
     chain: '',
   }
 
+  currencyTypes = ['USD']
+  blockChains = ['ETH', 'ALGO']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false

--- a/pages/debug/businessAccount/addresses/deposit/create.vue
+++ b/pages/debug/businessAccount/addresses/deposit/create.vue
@@ -9,11 +9,7 @@
             label="Currency"
           />
 
-          <ChainSelect
-            v-model="formData.chain"
-            label="Chain"
-            :disabled="loading"
-          />
+          <ChainSelect v-model="formData.chain" label="Chain" />
 
           <v-btn
             depressed

--- a/pages/debug/businessAccount/addresses/recipient/create.vue
+++ b/pages/debug/businessAccount/addresses/recipient/create.vue
@@ -5,11 +5,7 @@
         <v-form>
           <v-text-field v-model="formData.address" label="Recipient address" />
 
-          <ChainSelect
-            v-model="formData.chain"
-            label="Chain"
-            :disabled="loading"
-          />
+          <ChainSelect v-model="formData.chain" label="Chain" />
 
           <v-text-field v-model="formData.description" label="Description" />
 

--- a/pages/debug/businessAccount/addresses/recipient/create.vue
+++ b/pages/debug/businessAccount/addresses/recipient/create.vue
@@ -5,7 +5,11 @@
         <v-form>
           <v-text-field v-model="formData.address" label="Recipient address" />
 
-          <v-text-field v-model="formData.chain" label="Chain" />
+          <v-select
+            v-model="formData.chain"
+            :items="blockChains"
+            label="Chain"
+          />
 
           <v-text-field v-model="formData.description" label="Description" />
 
@@ -63,6 +67,7 @@ export default class CreateRecipientAddressClass extends Vue {
     description: '',
   }
 
+  blockChains = ['ETH', 'ALGO']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false

--- a/pages/debug/businessAccount/addresses/recipient/create.vue
+++ b/pages/debug/businessAccount/addresses/recipient/create.vue
@@ -7,7 +7,6 @@
 
           <ChainSelect
             v-model="formData.chain"
-            :rules="[rules.required]"
             label="Chain"
             :disabled="loading"
           />
@@ -68,10 +67,6 @@ export default class CreateRecipientAddressClass extends Vue {
     address: '',
     chain: '',
     description: '',
-  }
-
-  rules = {
-    required: (v: string) => !!v || 'Field is required',
   }
 
   error = {}

--- a/pages/debug/businessAccount/addresses/recipient/create.vue
+++ b/pages/debug/businessAccount/addresses/recipient/create.vue
@@ -5,10 +5,11 @@
         <v-form>
           <v-text-field v-model="formData.address" label="Recipient address" />
 
-          <v-select
+          <ChainSelect
             v-model="formData.chain"
-            :items="blockChains"
+            :rules="[rules.required]"
             label="Chain"
+            :disabled="loading"
           />
 
           <v-text-field v-model="formData.description" label="Description" />
@@ -47,10 +48,12 @@ import { v4 as uuidv4 } from 'uuid'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
 import { CreateRecipientAddressPayload } from '@/lib/businessAccount/addressesApi'
+import ChainSelect from '@/components/ChainSelect.vue'
 @Component({
   components: {
     RequestInfo,
     ErrorSheet,
+    ChainSelect,
   },
   computed: {
     ...mapGetters({
@@ -67,8 +70,10 @@ export default class CreateRecipientAddressClass extends Vue {
     description: '',
   }
 
-  blockChains = ['ETH', 'ALGO']
-  required = [(v: string) => !!v || 'Field is required']
+  rules = {
+    required: (v: string) => !!v || 'Field is required',
+  }
+
   error = {}
   loading = false
   showError = false

--- a/pages/debug/wallets/addresses/create.vue
+++ b/pages/debug/wallets/addresses/create.vue
@@ -16,7 +16,6 @@
           />
           <ChainSelect
             v-model="formData.chain"
-            :rules="[rules.required]"
             label="Chain"
             :disabled="loading"
           />
@@ -79,9 +78,6 @@ export default class CreateAddressClass extends Vue {
     chain: '',
   }
 
-  rules = {
-    required: (v: string) => !!v || 'Field is required',
-  }
 
   currencyTypes = ['USD']
 

--- a/pages/debug/wallets/addresses/create.vue
+++ b/pages/debug/wallets/addresses/create.vue
@@ -14,11 +14,7 @@
             label="Currency"
             hint="Currently, only USD is supported."
           />
-          <ChainSelect
-            v-model="formData.chain"
-            label="Chain"
-            :disabled="loading"
-          />
+          <ChainSelect v-model="formData.chain" label="Chain" />
           <v-btn
             depressed
             class="mb-7"
@@ -77,7 +73,6 @@ export default class CreateAddressClass extends Vue {
     currency: '',
     chain: '',
   }
-
 
   currencyTypes = ['USD']
 

--- a/pages/debug/wallets/addresses/create.vue
+++ b/pages/debug/wallets/addresses/create.vue
@@ -14,11 +14,11 @@
             label="Currency"
             hint="Currently, only USD is supported."
           />
-          <v-select
+          <ChainSelect
             v-model="formData.chain"
-            :items="blockChains"
-            label="Blockchain"
-            hint="Currently, only ETH is supported."
+            :rules="[rules.required]"
+            label="Chain"
+            :disabled="loading"
           />
           <v-btn
             depressed
@@ -52,11 +52,13 @@ import { Component, Vue } from 'nuxt-property-decorator'
 import { mapGetters } from 'vuex'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
+import ChainSelect from '@/components/ChainSelect.vue'
 
 @Component({
   components: {
     RequestInfo,
     ErrorSheet,
+    ChainSelect,
   },
   computed: {
     ...mapGetters({
@@ -77,8 +79,11 @@ export default class CreateAddressClass extends Vue {
     chain: '',
   }
 
+  rules = {
+    required: (v: string) => !!v || 'Field is required',
+  }
+
   currencyTypes = ['USD']
-  blockChains = ['ETH', 'ALGO']
 
   // methods
   onErrorSheetClosed() {

--- a/pages/debug/wallets/addresses/create.vue
+++ b/pages/debug/wallets/addresses/create.vue
@@ -78,7 +78,7 @@ export default class CreateAddressClass extends Vue {
   }
 
   currencyTypes = ['USD']
-  blockChains = ['ETH']
+  blockChains = ['ETH', 'ALGO']
 
   // methods
   onErrorSheetClosed() {


### PR DESCRIPTION
- Add ALGO as an allowed dropdown value for the path `POST /{walletId}/addresses`
- Add the same dropdown to `POST /businessAccount/wallets/addresses/recipient`
- Add the same dropdown to `POST /businessAccount/wallets/addresses/deposit`
- Add a currency dropdown to `POST /businessAccount/wallets/addresses/deposit`