### PR TITLE
[BRAAV-2252] Fix card expiry year

### DIFF
--- a/components/CreateCardForm.vue
+++ b/components/CreateCardForm.vue
@@ -217,7 +217,7 @@ export default class CreateCardFormClass extends Vue {
     const payload: CreateCardPayload = {
       idempotencyKey: uuidv4(),
       expMonth: parseInt(expiry.month),
-      expYear: 2000 + parseInt(expiry.year),
+      expYear: parseInt(expiry.year),
       keyId: '',
       encryptedData: '',
       billingDetails,

--- a/components/ExpiryInput.vue
+++ b/components/ExpiryInput.vue
@@ -2,7 +2,7 @@
   <v-text-field
     ref="expiry"
     v-model="vModel"
-    v-mask="'## / ##'"
+    v-mask="'## / ####'"
     placeholder="01 / 23"
     type="tel"
     label="Expiry"
@@ -73,12 +73,18 @@ export default class ExpiryInput extends Vue {
           return 'Please enter a valid date'
         }
         if (expMonth > 12) {
-          return 'Please enter a valid date'
+          return 'Please enter a valid month'
         }
-        const expiryDate = new Date(2000 + expYear, expMonth)
+
+        if (expYear < 1000) {
+          return 'Year has to be 4 digits'
+        }
+
+        const expiryDate = new Date(expYear, expMonth)
         if (isNaN(expiryDate.getFullYear())) {
           return 'Please enter a valid date'
         }
+
         if (expiryDate < new Date()) {
           return 'Date has expired'
         }

--- a/lib/cardTestData.ts
+++ b/lib/cardTestData.ts
@@ -6,7 +6,7 @@ export const exampleCards = [
       cvv: '123',
       expiry: {
         month: '01',
-        year: '25',
+        year: '2025',
       },
       name: 'Customer 0001',
       country: 'US',
@@ -26,7 +26,7 @@ export const exampleCards = [
       cvv: '123',
       expiry: {
         month: '01',
-        year: '25',
+        year: '2025',
       },
       name: 'Customer 0002',
       country: 'US',
@@ -46,7 +46,7 @@ export const exampleCards = [
       cvv: '123',
       expiry: {
         month: '01',
-        year: '25',
+        year: '2025',
       },
       name: 'Customer 0003',
       country: 'US',
@@ -66,7 +66,7 @@ export const exampleCards = [
       cvv: '123',
       expiry: {
         month: '01',
-        year: '25',
+        year: '2025',
       },
       name: 'Customer 0004',
       country: 'US',
@@ -86,7 +86,7 @@ export const exampleCards = [
       cvv: '123',
       expiry: {
         month: '01',
-        year: '25',
+        year: '2025',
       },
       name: 'Customer 0005',
       country: 'US',
@@ -106,7 +106,7 @@ export const exampleCards = [
       cvv: '123',
       expiry: {
         month: '01',
-        year: '25',
+        year: '2025',
       },
       name: 'Customer 0006',
       country: 'US',
@@ -126,7 +126,7 @@ export const exampleCards = [
       cvv: '123',
       expiry: {
         month: '01',
-        year: '25',
+        year: '2025',
       },
       name: 'Customer 0007',
       country: 'US',

--- a/pages/debug/cards/create.vue
+++ b/pages/debug/cards/create.vue
@@ -196,7 +196,7 @@ export default class CreateCardClass extends Vue {
     const payload: CreateCardPayload = {
       idempotencyKey: uuidv4(),
       expMonth: parseInt(expiry.month),
-      expYear: 2000 + parseInt(expiry.year),
+      expYear: parseInt(expiry.year),
       keyId: '',
       encryptedData: '',
       billingDetails,

--- a/pages/debug/cards/update.vue
+++ b/pages/debug/cards/update.vue
@@ -43,14 +43,12 @@ import { mapGetters } from 'vuex'
 import openPGP from '@/lib/openpgp'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
-import ExpiryInput from '@/components/ExpiryInput.vue'
 import { getLive } from '@/lib/apiTarget'
 
 @Component({
   components: {
     RequestInfo,
     ErrorSheet,
-    ExpiryInput,
   },
   computed: {
     ...mapGetters({
@@ -103,7 +101,7 @@ export default class UpdateCardsClass extends Vue {
 
     const payload = {
       expMonth: parseInt(expiry.month),
-      expYear: 2000 + parseInt(expiry.year),
+      expYear: parseInt(expiry.year),
       keyId: '',
       encryptedData: '',
     }

--- a/pages/flow/charge/index.vue
+++ b/pages/flow/charge/index.vue
@@ -376,7 +376,7 @@ export default class ChargeFlowClass extends Vue {
     const payload: CreateCardPayload = {
       idempotencyKey: uuidv4(),
       expMonth: parseInt(this.formData.cardData.expiry.month),
-      expYear: 2000 + parseInt(this.formData.cardData.expiry.year),
+      expYear: parseInt(this.formData.cardData.expiry.year),
       keyId: '',
       encryptedData: '',
       billingDetails: {


### PR DESCRIPTION
Bug: When user enters `2025` in the expiry year input field on `/debug/cards/create` or `/debug/cards/update` the api call is made with the value `4025`.

Make sure the payload looks correct creating a card on these pages:
http://localhost:3011/debug/cards/create
http://localhost:3011/debug/cards/update
http://localhost:3011/flow/card/create
http://localhost:3011/flow/charge/existing-card
http://localhost:3011/flow/card/create


