### PR TITLE
Fix placeholder for expiry date

### DIFF
--- a/components/ExpiryInput.vue
+++ b/components/ExpiryInput.vue
@@ -3,7 +3,7 @@
     ref="expiry"
     v-model="vModel"
     v-mask="'## / ####'"
-    placeholder="01 / 23"
+    placeholder="01 / 2023"
     type="tel"
     label="Expiry"
     :required="required"


### PR DESCRIPTION
Fix incorrect placeholder for expiry input.

<img width="808" alt="Screenshot 2020-11-23 at 12 30 56" src="https://user-images.githubusercontent.com/60018266/99957302-c7bfc200-2d87-11eb-9b2b-ef1441258737.png">
