### PR TITLE
Fix destination.type value for Biz Acct Transfers endpoint

### DIFF
--- a/pages/debug/businessAccount/transfers/create.vue
+++ b/pages/debug/businessAccount/transfers/create.vue
@@ -63,7 +63,6 @@ export default class CreateTransferClass extends Vue {
     address_id: '',
   }
 
-  destinationTypes = ['account', 'address']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false
@@ -82,7 +81,7 @@ export default class CreateTransferClass extends Vue {
       currency: 'USD',
     }
     const destinationDetail = {
-      type: 'address',
+      type: 'verified_blockchain',
       addressId: this.formData.address_id,
     }
 


### PR DESCRIPTION
The value being supplied for a POST to create a Biz Acct transfer in the Sample App is incorrect: https://sample-sandbox.circle.com/debug/businessAccount/transfers/create

Specifically, the app supplies a value of address which is not allowed by the destination endpoint:

```
{
  "idempotencyKey": "7ee50812-4edd-47fb-a78f-7b69c9bbf040",
  "amount": {
    "amount": "10",
    "currency": "USD"
  },
  "destination": {
    "type": "address",
    "addressId": "<SOME_RANDOM_ADDRESS_UUID>"
  }
}
```

We want to change `destination.type` to type `verified_blockchain` to reflect changes on the official Circle API reference, relative to business account transfers as seen [here](https://developers.circle.com/reference/transfers).