### PR TITLE
Create mock ach bank account

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -342,6 +342,10 @@ export default class DefaultLayoutsClass extends Vue {
       to: '/debug/wires/instructions',
     },
     {
+      title: 'POST /mocks/ach/accounts',
+      to: '/debug/ach/mocks/create',
+    },
+    {
       title: 'POST /banks/ach',
       to: '/debug/ach/create',
     },
@@ -445,6 +449,10 @@ export default class DefaultLayoutsClass extends Vue {
       to: '/debug/wires/instructions',
     },
     {
+      title: 'POST /mocks/ach/accounts',
+      to: '/debug/ach/mocks/create',
+    },
+    {
       title: 'POST /banks/ach',
       to: '/debug/ach/create',
     },
@@ -506,6 +514,18 @@ export default class DefaultLayoutsClass extends Vue {
     {
       title: 'GET /wires/{id}/instructions',
       to: '/debug/wires/instructions',
+    },
+    {
+      title: 'POST /mocks/ach/accounts',
+      to: '/debug/ach/mocks/create',
+    },
+    {
+      title: 'POST /banks/ach',
+      to: '/debug/ach/create',
+    },
+    {
+      title: 'GET /banks/ach/{id}',
+      to: '/debug/ach/details',
     },
     {
       title: 'POST /transfers',

--- a/lib/mocksApi.ts
+++ b/lib/mocksApi.ts
@@ -15,6 +15,18 @@ export interface CreateMockChargebackPayload {
   paymentId: string
 }
 
+export interface CreateMockACHBankAccount {
+  account: {
+    accountNumber: string
+    routingNumber: string
+    description: string
+  }
+  balance: {
+    amount: string
+    currency: string
+  }
+}
+
 const instance = axios.create({
   baseURL: getAPIHostname(),
 })
@@ -50,7 +62,7 @@ function getInstance() {
  * @param {*} payload
  */
 function createMockWirePayment(payload: CreateMockWirePaymentPayload) {
-  const url = 'v1/mocks/payments/wire'
+  const url = '/v1/mocks/payments/wire'
   return instance.post(url, payload)
 }
 
@@ -59,7 +71,16 @@ function createMockWirePayment(payload: CreateMockWirePaymentPayload) {
  * @param {*} payload
  */
 function createMockChargeback(payload: CreateMockChargebackPayload) {
-  const url = 'v1/mocks/cards/chargebacks'
+  const url = '/v1/mocks/cards/chargebacks'
+  return instance.post(url, payload)
+}
+
+/**
+ * Create a mock ACH bank account
+ * @param {*} payload
+ */
+function createMockACHBankAccount(payload: CreateMockACHBankAccount) {
+  const url = '/v1/mocks/ach/accounts'
   return instance.post(url, payload)
 }
 
@@ -67,4 +88,5 @@ export default {
   getInstance,
   createMockWirePayment,
   createMockChargeback,
+  createMockACHBankAccount,
 }

--- a/pages/debug/ach/mocks/create.vue
+++ b/pages/debug/ach/mocks/create.vue
@@ -5,25 +5,34 @@
         <v-form>
           <v-text-field
             v-model="formData.account.accountNumber"
+            :rules="[rules.required]"
             label="ACH Account Number"
+            required
           />
 
           <v-text-field
             v-model="formData.account.routingNumber"
+            :rules="[rules.required]"
             label="ACH Account Routing Number"
+            required
           />
 
           <v-text-field
             v-model="formData.account.description"
+            :rules="[rules.required]"
             label="ACH Account Description"
+            required
           />
 
           <v-text-field
             v-model="formData.balance.amount"
+            :rules="[rules.required]"
             label="ACH Account Balance"
+            required
           />
 
           <v-btn
+            v-if="isSandbox"
             depressed
             color="primary"
             :loading="loading"
@@ -80,6 +89,10 @@ export default class CreateCardClass extends Vue {
       amount: '0.00',
       currency: 'USD',
     },
+  }
+
+  rules = {
+    required: (v: string) => !!v || 'Field is required',
   }
 
   error = {}

--- a/pages/debug/ach/mocks/create.vue
+++ b/pages/debug/ach/mocks/create.vue
@@ -1,0 +1,119 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="formData.account.accountNumber"
+            label="ACH Account Number"
+          />
+
+          <v-text-field
+            v-model="formData.account.routingNumber"
+            label="ACH Account Routing Number"
+          />
+
+          <v-text-field
+            v-model="formData.account.description"
+            label="ACH Account Description"
+          />
+
+          <v-text-field
+            v-model="formData.balance.amount"
+            label="ACH Account Balance"
+          />
+
+          <v-btn
+            depressed
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import { getLive } from '@/lib/apiTarget'
+import { CreateMockACHBankAccount } from '@/lib/mocksApi'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+    }),
+  },
+})
+export default class CreateCardClass extends Vue {
+  formData = {
+    account: {
+      accountNumber: '',
+      routingNumber: '',
+      description: '',
+    },
+    balance: {
+      amount: '0.00',
+      currency: 'USD',
+    },
+  }
+
+  error = {}
+  loading = false
+  showError = false
+
+  isSandbox: Boolean = !getLive()
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  async makeApiCall() {
+    this.loading = true
+
+    const payload: CreateMockACHBankAccount = {
+      account: {
+        accountNumber: this.formData.account.accountNumber,
+        routingNumber: this.formData.account.routingNumber,
+        description: this.formData.account.description,
+      },
+      balance: {
+        amount: this.formData.balance.amount,
+        currency: this.formData.balance.currency,
+      },
+    }
+    try {
+      await this.$mocksApi.createMockACHBankAccount(payload)
+    } catch (error) {
+      this.error = error
+      this.showError = true
+    } finally {
+      this.loading = false
+    }
+  }
+}
+</script>

--- a/pages/debug/index.vue
+++ b/pages/debug/index.vue
@@ -43,6 +43,13 @@
 
         <p>
           <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/ach/mocks/create">
+            Create or update a mock ACH bank account
+          </a>
+        </p>
+
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
           <a href="/debug/ach/create">
             Add Plaid ACH account
           </a>

--- a/pages/debug/index.vue
+++ b/pages/debug/index.vue
@@ -44,7 +44,7 @@
         <p>
           <v-chip small color="primary warning">POST</v-chip>
           <a href="/debug/ach/mocks/create">
-            Create or update a mock ACH bank account
+            Create a mock ACH bank account
           </a>
         </p>
 

--- a/pages/debug/payouts/index.vue
+++ b/pages/debug/payouts/index.vue
@@ -65,7 +65,7 @@
         <p>
           <v-chip small color="primary warning">POST</v-chip>
           <a href="/debug/ach/mocks/create">
-            Create or update a mock ACH bank account
+            Create a mock ACH bank account
           </a>
         </p>
 

--- a/pages/debug/payouts/index.vue
+++ b/pages/debug/payouts/index.vue
@@ -55,6 +55,36 @@
       </v-card>
 
       <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h2 class="title">ACH accounts endpoints</h2>
+        <span class="caption">Requires: api key</span>
+        <br /><br />
+        <p>
+          Api endpoints to manage Plaid ACH accounts:
+        </p>
+
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/ach/mocks/create">
+            Create or update a mock ACH bank account
+          </a>
+        </p>
+
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/ach/create">
+            Add Plaid ACH account
+          </a>
+        </p>
+
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/ach/details">
+            Get ACH account details by id
+          </a>
+        </p>
+      </v-card>
+
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
         <h2 class="title">Transfers endpoints</h2>
         <span class="caption">Requires: api key</span>
         <br /><br />

--- a/plugins/mocksApi.ts
+++ b/plugins/mocksApi.ts
@@ -1,6 +1,7 @@
 import mocksApi, {
   CreateMockChargebackPayload,
   CreateMockWirePaymentPayload,
+  CreateMockACHBankAccount,
 } from '@/lib/mocksApi'
 
 declare module 'vue/types/vue' {
@@ -9,6 +10,7 @@ declare module 'vue/types/vue' {
       getInstance: any
       createMockChargeback: (payload: CreateMockChargebackPayload) => any
       createMockWirePayment: (payload: CreateMockWirePaymentPayload) => any
+      createMockACHBankAccount: (payload: CreateMockACHBankAccount) => any
     }
   }
 }


### PR DESCRIPTION
## New feature
Add support to create mock ACH bank account with specified balance and account numbuer/routing/description. 
This endpoint will return a mock plaid processor token that can be use in circle sandbox to create an ach fiat account.

## Payments APIs screen shot
<img width="1996" alt="Screen Shot 2021-01-05 at 12 59 25 PM" src="https://user-images.githubusercontent.com/52761714/103681980-3af74f00-4f56-11eb-9ce0-2a3b42e3b4b0.png">

## Payouts APIs screen shot
@geehsien Per our discussion, I also bring in creating ach accounts to payouts API.
<img width="1995" alt="Screen Shot 2021-01-05 at 12 59 57 PM" src="https://user-images.githubusercontent.com/52761714/103682046-54989680-4f56-11eb-8bb4-f012f4c37f73.png">
