### PR TITLE
Default to sandbox env

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ You can manually clone the sample app by running:
 $ git clone https://github.com/circlefin/payments-sample-app.git
 ```
 
-Create a `.env` file in the project's root folder in order to configure the base url for api calls. To run the sample app against the sandbox environment API endpoints, configure it as follows:
-
-```bash
-$ echo BASE_URL=https://api-sandbox.circle.com > .env
-```
-
 ## Install the dependencies
 
 Run the following to install the dependencies:
@@ -45,6 +39,16 @@ You are now ready to use the sample app and test some payments flows. In a produ
 ## Test Card Numbers
 
 To automatically trigger certain responses from the Circle Payments API, you can use some pre-defined [test card numbers](https://developers.circle.com/docs/test-card-numbers) that exercise specific behaviors.
+
+## Change API base url
+
+By default the API base url will be set to https://api-sandbox.circle.com.
+
+If you would like to point to another API base url you need to create a `.env` file in the project's root folder and configure it as follows:
+
+```bash
+$ echo BASE_URL=https://[base-url.com] > .env
+```
 
 ## Nuxt
 

--- a/lib/apiTarget.ts
+++ b/lib/apiTarget.ts
@@ -6,14 +6,17 @@
  */
 
 function getAPIHostname() {
-  // If the URL is provided via an environment variable (ie, in dev) use that.
+  // If app is running on localhost (ie, in  dev) the URL is provided via an environment variable (.env file), use that.
   // Otherwise, base it off the window location.
-  return process.env.baseUrl || window.location.origin.replace('sample', 'api')
+  if (window.location && window.location.hostname === 'localhost') {
+    return process.env.baseUrl
+  }
+  return window.location.origin.replace('sample', 'api')
 }
 
 function getLive() {
   const hostname = getAPIHostname()
-  return !(hostname.includes('sandbox') || hostname.includes('smokebox'))
+  return !(hostname!.includes('sandbox') || hostname!.includes('smokebox'))
 }
 
 export { getAPIHostname, getLive }

--- a/lib/openpgp.ts
+++ b/lib/openpgp.ts
@@ -18,7 +18,7 @@ interface PublicKey {
  */
 async function encrypt(dataToEncrypt: object, { keyId, publicKey }: PublicKey) {
   if (!publicKey || !keyId) {
-    return ''
+    throw new Error('Unable to encrypt data')
   }
 
   const decodedPublicKey = atob(publicKey)

--- a/lib/openpgp.ts
+++ b/lib/openpgp.ts
@@ -17,6 +17,10 @@ interface PublicKey {
  * @return {Object} Object containing encryptedMessage and keyId
  */
 async function encrypt(dataToEncrypt: object, { keyId, publicKey }: PublicKey) {
+  if (!publicKey || !keyId) {
+    return ''
+  }
+
   const decodedPublicKey = atob(publicKey)
   const openpgp = await openpgpModule
   const options = {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -105,6 +105,6 @@ export default {
     },
   },
   env: {
-    baseUrl: process.env.BASE_URL,
+    baseUrl: process.env.BASE_URL || 'https://api-sandbox.circle.com',
   },
 }

--- a/test/unit/lib/apiTarget.spec.js
+++ b/test/unit/lib/apiTarget.spec.js
@@ -10,7 +10,9 @@ describe('apiTarget', () => {
     }
   })
 
-  test('returns environment variable if its set', () => {
+  test('returns environment variable if localhost', () => {
+    window.location.hostname = 'localhost'
+
     process.env.baseUrl = 'foobar'
 
     expect(getAPIHostname()).toStrictEqual('foobar')


### PR DESCRIPTION
**Error message**
`Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.`
Also reported here: https://github.com/circlefin/payments-sample-app/issues/69

**Background**
The error results from the undefined `BASE_URL` due to either misconfiguration of `.env` file or an issue of Nuxt reading from the `.env` file (reported on Windows).

Series of events:
1. App is calling `/v1/encryption/public` without BASE_URL
2. Response does not contain `publicKey`, `keyId`
3. `atob(publicKey)` is called with undefined

**Solution**
- Default to sandbox environment (no configuration needed when setting up the repo)
- Do not call `atob` if `publicKey` is undefined