### PR TITLE
[BRAAV-4302] Add currency param to match transfers endpoint

### DIFF
--- a/lib/businessAccount/addressesApi.ts
+++ b/lib/businessAccount/addressesApi.ts
@@ -14,6 +14,7 @@ export interface CreateRecipientAddressPayload {
   address: string
   addressTag?: string
   chain: string
+  currency: string
   description: string
 }
 

--- a/lib/businessAccount/addressesApi.ts
+++ b/lib/businessAccount/addressesApi.ts
@@ -14,7 +14,7 @@ export interface CreateRecipientAddressPayload {
   address: string
   addressTag?: string
   chain: string
-  currency: string
+  currency?: string
   description: string
 }
 
@@ -79,6 +79,7 @@ function getDepositAddresses() {
  */
 function createRecipientAddress(payload: CreateRecipientAddressPayload) {
   const url = '/v1/businessAccount/wallets/addresses/recipient'
+  payload.currency = nullIfEmpty(payload.currency)
   return instance.post(url, payload)
 }
 

--- a/pages/debug/businessAccount/addresses/recipient/create.vue
+++ b/pages/debug/businessAccount/addresses/recipient/create.vue
@@ -7,6 +7,8 @@
 
           <v-text-field v-model="formData.address" label="Recipient address" />
 
+          <v-text-field v-model="formData.currency" label="Currency" />
+
           <v-text-field
             v-if="hasAddressTagSupport(formData.chain)"
             v-model="formData.addressTag"
@@ -70,6 +72,7 @@ export default class CreateRecipientAddressClass extends Vue {
   formData = {
     address: '',
     chain: '',
+    currency: '',
     description: '',
     addressTag: '',
   }
@@ -92,11 +95,12 @@ export default class CreateRecipientAddressClass extends Vue {
 
   async makeApiCall() {
     this.loading = true
-    const { address, chain, description, addressTag } = this.formData
+    const { address, chain, currency, description, addressTag } = this.formData
     const payload: CreateRecipientAddressPayload = {
       idempotencyKey: uuidv4(),
       address,
       chain,
+      currency,
       description,
     }
 


### PR DESCRIPTION
This adds an optional `currency` param to the business account "add recipient address" endpoint form.
