### PR TITLE
[BRAAV-4094] Expose Feature for Mock Sepa Push Payments

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -314,6 +314,10 @@ export default class DefaultLayoutsClass extends Vue {
       to: '/debug/payments/mocks/wire',
     },
     {
+      title: 'POST /mocks/payments/sepa',
+      to: '/debug/payments/mocks/sepa',
+    },
+    {
       title: 'POST /cards',
       to: '/debug/cards/create',
     },

--- a/lib/mocksApi.ts
+++ b/lib/mocksApi.ts
@@ -11,6 +11,14 @@ export interface CreateMockWirePaymentPayload {
   }
 }
 
+export interface CreateMockSEPAPaymentPayload {
+  trackingRef: string
+  amount: {
+    amount: string
+    currency: string
+  }
+}
+
 export interface CreateMockChargebackPayload {
   paymentId: string
 }
@@ -67,6 +75,15 @@ function createMockWirePayment(payload: CreateMockWirePaymentPayload) {
 }
 
 /**
+ * Trigger a mock sepa payment
+ * @param {*} payload
+ */
+function createMockSEPAPayment(payload: CreateMockSEPAPaymentPayload) {
+  const url = '/v1/mocks/payments/sepa'
+  return instance.post(url, payload)
+}
+
+/**
  * Create a mock chargeback
  * @param {*} payload
  */
@@ -87,6 +104,7 @@ function createMockACHBankAccount(payload: CreateMockACHBankAccount) {
 export default {
   getInstance,
   createMockWirePayment,
+  createMockSEPAPayment,
   createMockChargeback,
   createMockACHBankAccount,
 }

--- a/pages/debug/payments/mocks/sepa.vue
+++ b/pages/debug/payments/mocks/sepa.vue
@@ -1,0 +1,93 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.trackingRef" label="Tracking Ref" />
+          <v-text-field v-model="formData.amount" label="Amount" />
+          <v-btn
+            v-if="isSandbox"
+            depressed
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import { getLive } from '../../../../lib/apiTarget'
+import RequestInfo from '../../../../components/RequestInfo.vue'
+import ErrorSheet from '../../../../components/ErrorSheet.vue'
+import { CreateMockSEPAPaymentPayload } from '@/lib/mocksApi'
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+    }),
+  },
+})
+export default class CreateMockSEPAClass extends Vue {
+  formData = {
+    trackingRef: '',
+    amount: '0.00',
+  }
+
+  isSandbox: Boolean = !getLive()
+  required = [(v: string) => !!v || 'Field is required']
+  error = {}
+  loading = false
+  showError = false
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  async makeApiCall() {
+    this.loading = true
+    const amountDetail = {
+      amount: this.formData.amount,
+      currency: 'EUR',
+    }
+    const payload: CreateMockSEPAPaymentPayload = {
+      trackingRef: this.formData.trackingRef,
+      amount: amountDetail,
+    }
+
+    try {
+      await this.$mocksApi.createMockSEPAPayment(payload)
+    } catch (error) {
+      this.error = error
+      this.showError = true
+    } finally {
+      this.loading = false
+    }
+  }
+}
+</script>

--- a/plugins/mocksApi.ts
+++ b/plugins/mocksApi.ts
@@ -2,6 +2,7 @@ import mocksApi, {
   CreateMockChargebackPayload,
   CreateMockWirePaymentPayload,
   CreateMockACHBankAccount,
+  CreateMockSEPAPaymentPayload,
 } from '@/lib/mocksApi'
 
 declare module 'vue/types/vue' {
@@ -10,6 +11,7 @@ declare module 'vue/types/vue' {
       getInstance: any
       createMockChargeback: (payload: CreateMockChargebackPayload) => any
       createMockWirePayment: (payload: CreateMockWirePaymentPayload) => any
+      createMockSEPAPayment: (payload: CreateMockSEPAPaymentPayload) => any
       createMockACHBankAccount: (payload: CreateMockACHBankAccount) => any
     }
   }


### PR DESCRIPTION
Add new UI detail view for mocking sepa push payments via mock vendor resource.

<img width="1675" alt="Screenshot 2021-05-20 at 11 59 21" src="https://user-images.githubusercontent.com/75673545/118967801-09aa7900-b963-11eb-85a6-b4517e1617c9.png">

