### PR TITLE
Allow only test card numbers

### DIFF
--- a/pages/debug/cards/create.vue
+++ b/pages/debug/cards/create.vue
@@ -17,7 +17,7 @@
           <template v-slot:activator="{ on }">
             <div class="d-flex flex-row-reverse">
               <v-btn
-                v-if="!isSandbox"
+                v-if="isSandbox"
                 small
                 color="blue-grey lighten-1"
                 dark

--- a/pages/debug/cards/create.vue
+++ b/pages/debug/cards/create.vue
@@ -17,7 +17,7 @@
           <template v-slot:activator="{ on }">
             <div class="d-flex flex-row-reverse">
               <v-btn
-                v-if="isSandbox"
+                v-if="!isSandbox"
                 small
                 color="blue-grey lighten-1"
                 dark
@@ -39,7 +39,19 @@
         </v-menu>
 
         <v-form>
-          <v-text-field v-model="formData.cardNumber" label="Card Number" />
+          <v-select
+            v-if="isSandbox"
+            label="Card Number"
+            v-model="formData.cardNumber"
+            :items="testCardNumbers"
+          >
+          </v-select>
+
+          <v-text-field
+            v-if="!isSandbox"
+            v-model="formData.cardNumber"
+            label="Card Number"
+          />
 
           <v-text-field v-model="formData.cvv" label="CVV" />
 
@@ -158,6 +170,16 @@ export default class CreateCardClass extends Vue {
       v === '' || !isNaN(parseInt(v)) || 'Please enter valid number',
     required: (v: string) => !!v || 'Field is required',
   }
+
+  testCardNumbers = [
+    '4007400000000007',
+    '4007410000000006',
+    '4200000000000000',
+    '4757140000000001',
+    '5102420000000006',
+    '5173375000000006',
+    '5555555555554444',
+  ]
 
   prefillItems = exampleCards
   error = {}

--- a/pages/flow/charge/index.vue
+++ b/pages/flow/charge/index.vue
@@ -49,10 +49,19 @@
               />
 
               <CardInput
+                v-if="!isSandbox"
                 v-model="formData.cardData.cardNumber"
                 label="Card Number"
                 :disabled="loading"
               />
+
+              <v-select
+                v-if="isSandbox"
+                label="Card Number"
+                v-model="formData.cardData.cardNumber"
+                :items="testCardNumbers"
+              >
+              </v-select>
 
               <v-row>
                 <v-col cols="12" md="6">
@@ -311,6 +320,16 @@ export default class ChargeFlowClass extends Vue {
     },
     description: '',
   }
+
+  testCardNumbers = [
+    '4007400000000007',
+    '4007410000000006',
+    '4200000000000000',
+    '4757140000000001',
+    '5102420000000006',
+    '5173375000000006',
+    '5555555555554444',
+  ]
 
   rules = {
     isNumber: (v: string) =>


### PR DESCRIPTION
As a part of PCI compliance, We only want to allow inserting test card numbers in smokebox and sandbox

Instead of text input, we have added a dropdown with list of test card values for charge flow card page and POST/card page. 

<img width="1358" alt="Screenshot 2021-07-29 at 12 45 47" src="https://user-images.githubusercontent.com/75673545/127486581-fa05ab88-7e5b-46dc-a50a-79e1084d3865.png">
