### PR TITLE
Fix api url in local dev

### DIFF
--- a/lib/apiTarget.ts
+++ b/lib/apiTarget.ts
@@ -4,11 +4,15 @@
  * the client via a configuration endpoint), so we're stuck using this.  We can get away with
  * this because we have very consistent naming between our environments.
  */
-
 function getAPIHostname() {
   // If app is running on localhost (ie, in  dev) the URL is provided via an environment variable (.env file), use that.
   // Otherwise, base it off the window location.
-  if (window.location && window.location.hostname === 'localhost') {
+  const hostname = window.location && window.location.hostname
+  if (
+    hostname &&
+    !hostname.includes('sandbox') &&
+    !hostname.includes('smokebox')
+  ) {
     return process.env.baseUrl
   }
   return window.location.origin.replace('sample', 'api')


### PR DESCRIPTION
The logic to determine the `baseUrl` does not work in local dev if you open the app at `http://192.168.1.25:3011/ ` instead of `http://localhost:3011`.

<img width="402" alt="Screenshot 2021-12-09 at 14 35 53" src="https://user-images.githubusercontent.com/60018266/145406259-39ecc6e4-35bf-407f-8040-94d782ab6729.png">

Fix to allow both urls.