### PR TITLE
BRAAV-7847:  payments-sample-apps support: add payment ID as an optional query parameter to GET chargebacks API

### DIFF
--- a/lib/chargebacksApi.ts
+++ b/lib/chargebacksApi.ts
@@ -44,6 +44,7 @@ function getInstance() {
  * Get Settlements
  * @param {String} merchantId
  * @param {String} settlementId
+ * @param {String} paymentId
  * @param {String} from
  * @param {String} to
  * @param {String} pageBefore
@@ -53,6 +54,7 @@ function getInstance() {
 function getChargebacks(
   merchantId: string,
   settlementId: string,
+  paymentId: string,
   from: string,
   to: string,
   pageBefore: string,
@@ -62,6 +64,7 @@ function getChargebacks(
   const queryParams = {
     merchantId: nullIfEmpty(merchantId),
     settlementId: nullIfEmpty(settlementId),
+    paymentId: nullIfEmpty(paymentId),
     from: nullIfEmpty(from),
     to: nullIfEmpty(to),
     pageBefore: nullIfEmpty(pageBefore),

--- a/pages/debug/chargebacks/fetch.vue
+++ b/pages/debug/chargebacks/fetch.vue
@@ -10,6 +10,7 @@
           />
           <header>Optional filter params:</header>
           <v-text-field v-model="formData.settlementId" label="Settlement ID" />
+          <v-text-field v-model="formData.paymentId" label="Payment ID" />
           <v-text-field v-model="formData.from" label="From" />
           <v-text-field v-model="formData.to" label="To" />
           <v-text-field v-model="formData.pageSize" label="PageSize" />
@@ -65,6 +66,7 @@ export default class FetchChargebacksClass extends Vue {
   formData = {
     merchantId: '',
     settlementId: '',
+    paymentId: '',
     from: '',
     to: '',
     pageSize: '',
@@ -98,6 +100,7 @@ export default class FetchChargebacksClass extends Vue {
       await this.$chargebacksApi.getChargebacks(
         this.formData.merchantId,
         this.formData.settlementId,
+        this.formData.paymentId,
         this.formData.from,
         this.formData.to,
         this.formData.pageBefore,


### PR DESCRIPTION
## Problem
Client Bigtime Studios asked ”Is there a way to get a chargeback by the payment ID? That way we can get all chargebacks associated to a user or order”.

More detail: https://docs.google.com/document/d/1zKuPbqe4WZM05iBInsxm-cloeglOW0m7UvPQhhhOBXw/edit?usp=sharing - Connect to preview
This PR is used to add paymentId as one optional input in payments-sample-app to GET chargebacks endpoint.

## Solution
Add an optional input `paymentId` to `GET /v1/chargebacks ` payments-sample-app.

---

**Story:** <https://circlepay.atlassian.net/browse/BRAAV-7847>
