### PR TITLE
[NOTICKET] Explicitly send `autoCapture` in JSON request

### DIFF
--- a/pages/debug/marketplace/payments/create.vue
+++ b/pages/debug/marketplace/payments/create.vue
@@ -190,7 +190,7 @@ export default class CreatePaymentClass extends Vue {
 
     const payload: CreateMarketplaceCardPaymentPayload = {
       idempotencyKey: uuidv4(),
-      autoCapture: this.formData.autoCapture ? undefined : false,
+      autoCapture: this.formData.autoCapture,
       amount: amountDetail,
       source: sourceDetails,
       description: this.formData.description,

--- a/pages/debug/payments/create.vue
+++ b/pages/debug/payments/create.vue
@@ -177,7 +177,7 @@ export default class CreatePaymentClass extends Vue {
     }
     const payload: CreateCardPaymentPayload = {
       idempotencyKey: uuidv4(),
-      autoCapture: this.formData.autoCapture ? undefined : false,
+      autoCapture: this.formData.autoCapture,
       amount: amountDetail,
       source: sourceDetails,
       description: this.formData.description,


### PR DESCRIPTION
`autoCapture` is being coalesced to `undefined` when being sent to the POST payload: https://developers.circle.com/reference#payments-payments-create.

While `undefined` is allowed/correct from an API standpoint, the field is not documented in its behavior when not supplied and is confusing developers/readers. Instead, this PR makes the behavior more clear in `true`/`false` when submitting values.