### PR TITLE
UI for mock googlepay token creation and conversion

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -428,6 +428,10 @@ export default class DefaultLayoutsClass extends Vue {
       title: 'GET /balances',
       to: '/debug/payments/balances/fetch',
     },
+    {
+      title: 'POST /convertToken',
+      to: '/debug/payments/googlepay/convertToken',
+    },
   ]
 
   applePayStaging = {

--- a/lib/apiTarget.ts
+++ b/lib/apiTarget.ts
@@ -39,4 +39,11 @@ function getIsLocalHost(): boolean {
   return hostname!.includes(':3011')
 }
 
-export { getAPIHostname, getLive, getIsStaging, getIsLocalHost, getIsSandbox, getIsSmokebox }
+export {
+  getAPIHostname,
+  getLive,
+  getIsStaging,
+  getIsLocalHost,
+  getIsSandbox,
+  getIsSmokebox,
+}

--- a/lib/apiTarget.ts
+++ b/lib/apiTarget.ts
@@ -19,6 +19,16 @@ function getLive() {
   return !(hostname!.includes('sandbox') || hostname!.includes('smokebox'))
 }
 
+function getIsSmokebox() {
+  const hostname = getAPIHostname()
+  return hostname!.includes('smokebox')
+}
+
+function getIsSandbox() {
+  const hostname = getAPIHostname()
+  return hostname!.includes('sandbox')
+}
+
 function getIsStaging() {
   const hostname = getAPIHostname()
   return hostname!.includes('staging')
@@ -29,4 +39,4 @@ function getIsLocalHost(): boolean {
   return hostname!.includes(':3011')
 }
 
-export { getAPIHostname, getLive, getIsStaging, getIsLocalHost }
+export { getAPIHostname, getLive, getIsStaging, getIsLocalHost, getIsSandbox, getIsSmokebox }

--- a/lib/apiTarget.ts
+++ b/lib/apiTarget.ts
@@ -19,16 +19,6 @@ function getLive() {
   return !(hostname!.includes('sandbox') || hostname!.includes('smokebox'))
 }
 
-function getIsSmokebox() {
-  const hostname = getAPIHostname()
-  return hostname!.includes('smokebox')
-}
-
-function getIsSandbox() {
-  const hostname = getAPIHostname()
-  return hostname!.includes('sandbox')
-}
-
 function getIsStaging() {
   const hostname = getAPIHostname()
   return hostname!.includes('staging')
@@ -39,11 +29,4 @@ function getIsLocalHost(): boolean {
   return hostname!.includes(':3011')
 }
 
-export {
-  getAPIHostname,
-  getLive,
-  getIsStaging,
-  getIsLocalHost,
-  getIsSandbox,
-  getIsSmokebox,
-}
+export { getAPIHostname, getLive, getIsStaging, getIsLocalHost }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nuxtjs/dotenv": "1.4.1",
     "@nuxtjs/vuetify": "1.12.2",
     "@types/card-validator": "7.0.1",
+    "@types/googlepay": "^0.6.4",
     "@types/vue-the-mask": "0.11.1",
     "axios": "0.24.0",
     "card-validator": "8.1.1",

--- a/pages/debug/payments/googlepay/convertToken.vue
+++ b/pages/debug/payments/googlepay/convertToken.vue
@@ -61,7 +61,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
 import { mapGetters } from 'vuex'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
-import { getIsLocalHost, getIsSmokebox, getIsSandbox } from '~/lib/apiTarget'
+import { getLive } from '~/lib/apiTarget'
 
 @Component({
   components: {
@@ -99,7 +99,7 @@ export default class ConvertToken extends Vue {
   }
 
   showAutogenerateButton() {
-    return getIsLocalHost() || getIsSmokebox() || getIsSandbox()
+    return !getLive()
   }
 
   // autogenerate token info by assigning random strings to each field

--- a/pages/debug/payments/googlepay/convertToken.vue
+++ b/pages/debug/payments/googlepay/convertToken.vue
@@ -91,6 +91,7 @@ export default class ConvertToken extends Vue {
   error = {}
   loading = false
   showError = false
+  payload = {}
 
   onErrorSheetClosed() {
     this.error = {}
@@ -128,6 +129,7 @@ export default class ConvertToken extends Vue {
           token_data: 'TODO: implement apply pay payload',
         }
     }
+    this.payload = payload
     // TODO: implement API call to token converter endpoint once endpoint is finished for google pay
   }
 }

--- a/pages/debug/payments/googlepay/convertToken.vue
+++ b/pages/debug/payments/googlepay/convertToken.vue
@@ -1,0 +1,123 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-btn
+            depressed
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="autogenerateToken()"
+          >
+            Autogenerate token
+          </v-btn>
+
+          <v-select
+            v-model="formData.type"
+            :items="paymentType"
+            label="Payment Type"
+          />
+          <v-text-field v-model="formData.signature" label="Signature" />
+          <v-text-field
+            v-model="formData.signedMessage"
+            label="Signed Message"
+          />
+
+          <v-btn
+            depressed
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Convert Token
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+    }),
+  },
+})
+export default class ConvertToken extends Vue {
+  formData = {
+    type: 'Google Pay',
+    signature: '',
+    signedMessage: '',
+  }
+
+  paymentType = ['Google Pay', 'Apple Pay']
+  required = [(v: string) => !!v || 'Field is required']
+  error = {}
+  loading = false
+  showError = false
+
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  // autogenerate token info by assigning random strings to each field
+  autogenerateToken() {
+    this.formData.signature = Math.random().toString(36).substring(2, 12)
+    this.formData.signedMessage = Math.random().toString(36).substring(2, 12)
+  }
+
+  makeApiCall() {
+    const type = this.formData.type === 'Google Pay' ? 'googlepay' : 'applepay'
+    let payload = null
+
+    switch (type) {
+      case 'googlepay':
+        payload = {
+          type,
+          token_data: {
+            protocolVersion: 'ECv1',
+            signature: this.formData.signature,
+            signedMessage: this.formData.signedMessage,
+          },
+        }
+        break
+      case 'applepay':
+        payload = {
+          type,
+          token_data: 'TODO: implement apply pay payload',
+        }
+    }
+
+    console.log(payload)
+    // TODO: implement API call to token converter endpoint once endpoint is finished for google pay
+  }
+}
+</script>

--- a/pages/debug/payments/googlepay/convertToken.vue
+++ b/pages/debug/payments/googlepay/convertToken.vue
@@ -4,6 +4,7 @@
       <v-col cols="12" md="4">
         <v-form>
           <v-btn
+            v-if="showAutogenerateButton"
             depressed
             class="mb-7"
             color="primary"
@@ -12,11 +13,15 @@
           >
             Autogenerate token
           </v-btn>
-
           <v-select
             v-model="formData.type"
             :items="paymentType"
             label="Payment Type"
+          />
+          <v-select
+            v-model="formData.protocolVersion"
+            :items="protocolVersions"
+            label="Protocol Version"
           />
           <v-text-field v-model="formData.signature" label="Signature" />
           <v-text-field
@@ -56,6 +61,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
 import { mapGetters } from 'vuex'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
+import { getIsLocalHost, getIsSmokebox, getIsSandbox } from '~/lib/apiTarget'
 
 @Component({
   components: {
@@ -73,11 +79,14 @@ import ErrorSheet from '@/components/ErrorSheet.vue'
 export default class ConvertToken extends Vue {
   formData = {
     type: 'Google Pay',
+    protocolVersion: 'ECv1',
     signature: '',
     signedMessage: '',
   }
 
+  // const paymentsClient = new google.payments.api.PaymentsClient({ environment: 'TEST' })
   paymentType = ['Google Pay', 'Apple Pay']
+  protocolVersions = ['ECv1']
   required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false
@@ -86,6 +95,10 @@ export default class ConvertToken extends Vue {
   onErrorSheetClosed() {
     this.error = {}
     this.showError = false
+  }
+
+  showAutogenerateButton() {
+    return getIsLocalHost() || getIsSmokebox() || getIsSandbox()
   }
 
   // autogenerate token info by assigning random strings to each field
@@ -103,7 +116,7 @@ export default class ConvertToken extends Vue {
         payload = {
           type,
           token_data: {
-            protocolVersion: 'ECv1',
+            protocolVersion: this.formData.protocolVersion,
             signature: this.formData.signature,
             signedMessage: this.formData.signedMessage,
           },
@@ -115,8 +128,6 @@ export default class ConvertToken extends Vue {
           token_data: 'TODO: implement apply pay payload',
         }
     }
-
-    console.log(payload)
     // TODO: implement API call to token converter endpoint once endpoint is finished for google pay
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5607,7 +5607,7 @@ expect@^27.4.2:
     jest-message-util "^27.4.2"
     jest-regex-util "^27.4.0"
 
-express@4.17.3:
+express@^4.17.3:
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"
   integrity sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,6 +2134,11 @@
   dependencies:
     "@types/webpack" "^4"
 
+"@types/googlepay@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@types/googlepay/-/googlepay-0.6.4.tgz#e0b06ae1f12496c4fa43e52d35e76411dbbee135"
+  integrity sha512-PTt/UCllzl8z5HmhymPpSj6uENZvVKZvCBYdDVmbBVJnLStitxtWrterAOQZkKGlqVdzxNXYeif5hOAMNMS5mw==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.3.tgz#039af35fe26bec35003e8d86d2ee9c586354348f"
@@ -5602,7 +5607,7 @@ expect@^27.4.2:
     jest-message-util "^27.4.2"
     jest-regex-util "^27.4.0"
 
-express@^4.17.3:
+express@4.17.3:
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"
   integrity sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==


### PR DESCRIPTION
This is a PR for the UI to generate and convert a google pay token in payments sample app. 

- In smokebox/sandbox we will autogenerate a mock googlepay token (implemented in this PR)
- In stg/prod we will implement the real google pay button which will call the Google Pay API and return a real googlepay token (not implemented in this PR)
- The generated tokens will populate the form fields (implemented in this PR for the mock token)
- The convert token will call the endpoint in wallets-api and return the converted token (not implemented in this PR

<img width="1663" alt="Screen Shot 2022-03-01 at 12 30 09 PM" src="https://user-images.githubusercontent.com/38088920/156218904-b32a9814-bdf8-4481-b8ff-79e32fcb9002.png">
)