### PR TITLE
[BRAAV-8588] add new input field beneficiary account number to sample app mock wire

### DIFF
--- a/lib/mocksApi.ts
+++ b/lib/mocksApi.ts
@@ -5,6 +5,7 @@ import { getAPIHostname } from './apiTarget'
 
 export interface CreateMockPushPaymentPayload {
   trackingRef: string
+  beneficiaryAccountNumber: string
   amount: {
     amount: string
     currency: string

--- a/pages/debug/payments/mocks/sepa.vue
+++ b/pages/debug/payments/mocks/sepa.vue
@@ -56,6 +56,7 @@ import { CreateMockPushPaymentPayload } from '@/lib/mocksApi'
 export default class CreateMockSEPAClass extends Vue {
   formData = {
     trackingRef: '',
+    beneficiaryAccountNumber: '',
     amount: '0.00',
   }
 
@@ -77,6 +78,7 @@ export default class CreateMockSEPAClass extends Vue {
     }
     const payload: CreateMockPushPaymentPayload = {
       trackingRef: this.formData.trackingRef,
+      beneficiaryAccountNumber: this.formData.beneficiaryAccountNumber,
       amount: amountDetail,
     }
 

--- a/pages/debug/payments/mocks/wire.vue
+++ b/pages/debug/payments/mocks/wire.vue
@@ -4,6 +4,7 @@
       <v-col cols="12" md="4">
         <v-form>
           <v-text-field v-model="formData.trackingRef" label="Tracking Ref" />
+          <v-text-field v-model="formData.beneficiaryAccountNumber" label="Beneficiary Account Number" />
           <v-text-field v-model="formData.amount" label="Amount" />
           <v-btn
             v-if="isSandbox"
@@ -56,6 +57,7 @@ import { CreateMockPushPaymentPayload } from '@/lib/mocksApi'
 export default class CreateMockIncomingWireClass extends Vue {
   formData = {
     trackingRef: '',
+    beneficiaryAccountNumber: '',
     amount: '0.00',
   }
 
@@ -77,6 +79,7 @@ export default class CreateMockIncomingWireClass extends Vue {
     }
     const payload: CreateMockPushPaymentPayload = {
       trackingRef: this.formData.trackingRef,
+      beneficiaryAccountNumber: this.formData.beneficiaryAccountNumber,
       amount: amountDetail,
     }
 


### PR DESCRIPTION
We would need to add a new input field - Beneficiary account number to POST /mocks/payments/wire in sample app