### PR TITLE
Implement googlepay secrets and update wallets endpoint

### DIFF
--- a/lib/googlePay.ts
+++ b/lib/googlePay.ts
@@ -3,6 +3,9 @@ import PaymentDataRequest = google.payments.api.PaymentDataRequest
 import ButtonOptions = google.payments.api.ButtonOptions
 import IsReadyToPayResponse = google.payments.api.IsReadyToPayResponse
 import IsReadyToPayPaymentMethodSpecification = google.payments.api.IsReadyToPayPaymentMethodSpecification
+import PaymentMethodTokenizationSpecification = google.payments.api.PaymentMethodTokenizationSpecification
+import TransactionInfo = google.payments.api.TransactionInfo
+import Environment = google.payments.api.Environment
 
 const DEFAULT_CONFIG = {
   apiVersion: 2,
@@ -25,13 +28,27 @@ const DEFAULT_CONFIG = {
       gatewayMerchantId: 'YOUR_PUBLIC_KEY',
     },
   },
-  transactionInfo: {
+  transactionInfo: <TransactionInfo>{
     currencyCode: 'USD',
     countryCode: 'US',
     totalPriceStatus: 'FINAL',
-    totalPrice: '12.00',
     checkoutOption: 'COMPLETE_IMMEDIATE_PURCHASE',
   },
+  environment: <Environment>'TEST', // TODO: change to 'PRODUCTION' after completing testing
+}
+
+interface PaymentToken {
+  protocolVersion: string
+  signature: string
+  intermediateSigningKey: Object
+  signedMessage: string
+}
+
+interface PaymentRequestConfig {
+  amount: string
+  merchantId: string
+  merchantName: string
+  checkoutKey: string
 }
 
 function getIsReadyToPayRequest() {
@@ -43,43 +60,51 @@ function getIsReadyToPayRequest() {
   return isReadyToPayRequest
 }
 
-const paymentDataRequest: PaymentDataRequest = {
-  apiVersion: 2,
-  apiVersionMinor: 0,
-  merchantInfo: {
-    merchantId: '12345678901234567890',
-    merchantName: 'Example Merchant',
-  },
-  allowedPaymentMethods: [
-    {
-      type: 'CARD',
-      parameters: {
-        allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
-        allowedCardNetworks: ['MASTERCARD', 'VISA'],
-      },
-      tokenizationSpecification: {
-        type: 'PAYMENT_GATEWAY',
-        parameters: {
-          gateway: 'checkoutltd',
-          gatewayMerchantId: 'YOUR_PUBLIC_KEY',
-        },
-      },
-    },
-  ],
-  transactionInfo: {
-    currencyCode: 'USD',
-    countryCode: 'US',
-    totalPriceStatus: 'FINAL',
-    totalPrice: '12.00',
-    checkoutOption: 'COMPLETE_IMMEDIATE_PURCHASE',
-  },
-}
+function getPaymentDataRequest(config: PaymentRequestConfig) {
+  const amount = config.amount === null ? '0.00' : config.amount
+  const id =
+    config.merchantId === null
+      ? DEFAULT_CONFIG.merchantInfo.merchantId
+      : config.merchantId
+  const name =
+    config.merchantName === null
+      ? DEFAULT_CONFIG.merchantInfo.merchantName
+      : config.merchantName
+  const checkoutKey =
+    config.checkoutKey === null
+      ? DEFAULT_CONFIG.tokenizationSpecification.parameters.gatewayMerchantId
+      : config.checkoutKey
 
-interface PaymentToken {
-  protocolVersion: string
-  signature: string
-  intermediateSigningKey: Object
-  signedMessage: string
+  const paymentDataRequest: PaymentDataRequest = {
+    apiVersion: DEFAULT_CONFIG.apiVersion,
+    apiVersionMinor: DEFAULT_CONFIG.apiVersionMinor,
+    merchantInfo: {
+      merchantId: id,
+      merchantName: name,
+    },
+    allowedPaymentMethods: [
+      {
+        type: DEFAULT_CONFIG.allowedPaymentMethods.type,
+        parameters: DEFAULT_CONFIG.allowedPaymentMethods.parameters,
+        tokenizationSpecification: <PaymentMethodTokenizationSpecification>{
+          type: DEFAULT_CONFIG.tokenizationSpecification.type,
+          parameters: {
+            gateway:
+              DEFAULT_CONFIG.tokenizationSpecification.parameters.gateway,
+            gatewayMerchantId: checkoutKey,
+          },
+        }, // TODO: get merchantID from SSM
+      },
+    ],
+    transactionInfo: {
+      currencyCode: DEFAULT_CONFIG.transactionInfo.currencyCode,
+      countryCode: DEFAULT_CONFIG.transactionInfo.countryCode,
+      totalPriceStatus: DEFAULT_CONFIG.transactionInfo.totalPriceStatus,
+      totalPrice: amount,
+      checkoutOption: DEFAULT_CONFIG.transactionInfo.checkoutOption,
+    },
+  }
+  return paymentDataRequest
 }
 
 let paymentsClient: any = null
@@ -87,10 +112,15 @@ let paymentsClient: any = null
 function getGooglePaymentsClient() {
   if (paymentsClient === null) {
     paymentsClient = new google.payments.api.PaymentsClient({
-      environment: 'TEST', // TODO: get real environment once implementation is finished
+      environment: DEFAULT_CONFIG.environment,
     })
   }
   return paymentsClient
+}
+
+function addGooglePayButton(buttonOptions: ButtonOptions) {
+  const button = paymentsClient.createButton(buttonOptions)
+  document.getElementById('google-pay-button')?.append(button)
 }
 
 function onGooglePayLoaded(buttonOptions: ButtonOptions) {
@@ -99,8 +129,7 @@ function onGooglePayLoaded(buttonOptions: ButtonOptions) {
     .isReadyToPay(getIsReadyToPayRequest())
     .then(function (response: IsReadyToPayResponse) {
       if (response.result) {
-        const button = paymentsClient.createButton(buttonOptions)
-        document.getElementById('google-pay-button')?.append(button)
+        addGooglePayButton(buttonOptions)
       }
     })
     .catch(function (err: any) {
@@ -111,6 +140,8 @@ function onGooglePayLoaded(buttonOptions: ButtonOptions) {
 export {
   onGooglePayLoaded,
   getGooglePaymentsClient,
-  paymentDataRequest,
+  getPaymentDataRequest,
   PaymentToken,
+  PaymentRequestConfig,
+  DEFAULT_CONFIG,
 }

--- a/lib/googlePay.ts
+++ b/lib/googlePay.ts
@@ -32,6 +32,7 @@ const DEFAULT_CONFIG = {
     currencyCode: 'USD',
     countryCode: 'US',
     totalPriceStatus: 'FINAL',
+    totalPrice: '0.00',
     checkoutOption: 'COMPLETE_IMMEDIATE_PURCHASE',
   },
   environment: <Environment>'TEST', // TODO: change to 'PRODUCTION' after completing testing
@@ -61,7 +62,10 @@ function getIsReadyToPayRequest() {
 }
 
 function getPaymentDataRequest(config: PaymentRequestConfig) {
-  const amount = config.amount === null ? '0.00' : config.amount
+  const amount =
+    config.amount === null
+      ? DEFAULT_CONFIG.transactionInfo.totalPrice
+      : config.amount
   const id =
     config.merchantId === null
       ? DEFAULT_CONFIG.merchantInfo.merchantId

--- a/lib/walletsApi.ts
+++ b/lib/walletsApi.ts
@@ -1,5 +1,6 @@
 import get from 'lodash/get'
 import axios from 'axios'
+import { v4 as uuidv4 } from 'uuid'
 
 import { getAPIHostname } from './apiTarget'
 
@@ -109,11 +110,11 @@ function getMasterWallet() {
  * @param {UUID} idempotencyKey
  */
 function convertToken(type: string, tokenData: Object) {
-  const url = '/v1/tokens'
+  const url = '/v1/paymenttokens'
   const payload = {
     type,
     tokenData,
-    idempotencyKey: '394dffd9-e992-4b86-b3f3-0a242a44db48',
+    idempotencyKey: uuidv4(),
   }
   const config = {
     headers: { 'Access-Control-Allow-Origin': '*' },

--- a/pages/debug/payments/digitalWallets/convertToken.vue
+++ b/pages/debug/payments/digitalWallets/convertToken.vue
@@ -7,10 +7,11 @@
             v-model="formData.type"
             :items="paymentType"
             label="Payment Type"
-            @change="clearTokens()"
+            @change="onPaymentTypeChange()"
           />
+          <v-text-field v-model="formData.amount" label="Amount" />
           <v-btn
-            v-if="showAutogenerateButton()"
+            v-if="displayAutogenerateButton"
             outlined
             small
             depressed
@@ -20,7 +21,7 @@
           >
             Autogenerate token
           </v-btn>
-          <div v-if="showGooglePayButton()" id="google-pay-button"></div>
+          <div v-if="displayGooglePayButton" id="google-pay-button"></div>
           <v-card v-if="tokensGenerated" class="body-1 px-6 py-8 mb-4">
             <h2 class="title">Token Information</h2>
             <p class="font-weight-light mt-2">
@@ -70,11 +71,18 @@ import { getLive } from '~/lib/apiTarget'
 import {
   onGooglePayLoaded,
   getGooglePaymentsClient,
-  paymentDataRequest,
+  getPaymentDataRequest,
   PaymentToken,
+  PaymentRequestConfig,
+  DEFAULT_CONFIG,
 } from '~/lib/googlePay'
 import ButtonOptions = google.payments.api.ButtonOptions
 import PaymentData = google.payments.api.PaymentData
+import {
+  checkoutKey,
+  merchantId,
+  merchantName,
+} from '~/server-middleware/googlePaySettings'
 
 @Component({
   components: {
@@ -95,6 +103,7 @@ export default class ConvertToken extends Vue {
     protocolVersion: 'ECv1',
     signature: '',
     signedMessage: '',
+    amount: '0.00',
   }
 
   paymentType = ['Google Pay', 'Apple Pay']
@@ -102,19 +111,12 @@ export default class ConvertToken extends Vue {
   loading = false
   showError = false
   tokensGenerated = false
+  displayAutogenerateButton = !getLive()
+  displayGooglePayButton = this.formData.type === 'Google Pay' && getLive()
 
   buttonOptions: ButtonOptions = {
     onClick: this.onGooglePayButtonClicked,
-    allowedPaymentMethods: [
-      {
-        type: 'CARD',
-        parameters: {
-          allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
-          allowedCardNetworks: ['MASTERCARD', 'VISA'],
-        },
-      },
-    ],
-    buttonSizeMode: 'fill',
+    allowedPaymentMethods: [DEFAULT_CONFIG.allowedPaymentMethods],
   }
 
   mounted() {
@@ -126,16 +128,18 @@ export default class ConvertToken extends Vue {
     this.showError = false
   }
 
-  showAutogenerateButton() {
-    return !getLive()
-  }
-
-  showGooglePayButton() {
-    return this.formData.type === 'Google Pay' && getLive()
-  }
-
-  clearTokens() {
+  onPaymentTypeChange() {
     this.tokensGenerated = false
+    if (getLive()) {
+      switch (this.formData.type) {
+        case 'Google Pay':
+          this.displayGooglePayButton = true
+          break
+        case 'Apple Pay':
+          this.displayGooglePayButton = false
+          break
+      }
+    }
   }
 
   // autogenerate token info by assigning random strings to each field
@@ -147,8 +151,14 @@ export default class ConvertToken extends Vue {
 
   onGooglePayButtonClicked() {
     const paymentsClient = getGooglePaymentsClient()
+    const paymentDataConfig: PaymentRequestConfig = {
+      amount: this.formData.amount,
+      merchantName,
+      merchantId,
+      checkoutKey,
+    }
     paymentsClient
-      .loadPaymentData(paymentDataRequest)
+      .loadPaymentData(getPaymentDataRequest(paymentDataConfig))
       .then((paymentData: PaymentData) => {
         const paymentTokenString =
           paymentData.paymentMethodData.tokenizationData.token // payment token as JSON string
@@ -184,7 +194,6 @@ export default class ConvertToken extends Vue {
     } finally {
       this.loading = false
     }
-    // TODO: implement API call to /tokens endpoint
   }
 }
 </script>

--- a/server-middleware/googlePaySettings.ts
+++ b/server-middleware/googlePaySettings.ts
@@ -1,0 +1,19 @@
+const googlePaySecretsAreSet = !(
+  process.env.GOOGLE_PAY_MERCHANT_ID == null ||
+  process.env.GOOGLE_PAY_MERCHANT_NAME == null ||
+  process.env.GOOGLE_PAY_CHECKOUT_KEY == null
+)
+
+const merchantId: string = googlePaySecretsAreSet
+  ? process.env.GOOGLE_PAY_MERCHANT_ID!
+  : ''
+
+const merchantName: string = googlePaySecretsAreSet
+  ? process.env.GOOGLE_PAY_MERCHANT_NAME!
+  : ''
+
+const checkoutKey: string = googlePaySecretsAreSet
+  ? process.env.GOOGLE_PAY_CHECKOUT_KEY!
+  : ''
+
+export { merchantId, merchantName, checkoutKey }


### PR DESCRIPTION
This PR implements the following:

1. Access stored secrets for session validation
    - Implements `PaymentRequestConfig` interface to pass secrets to PaymentDataRequest object
2. Changes wallets endpoint to /paymenttokens
3. Utilize `DEFAULT_CONFIG` to create request objects in googlepay lib