### PR TITLE
Update tokens endpoint

### DIFF
--- a/lib/googlePay.ts
+++ b/lib/googlePay.ts
@@ -35,7 +35,10 @@ const DEFAULT_CONFIG = {
     totalPrice: '0.00',
     checkoutOption: 'COMPLETE_IMMEDIATE_PURCHASE',
   },
-  environment: <Environment>'TEST',
+  environment: {
+    test: <Environment>'TEST',
+    prod: <Environment>'PRODUCTION',
+  },
 }
 
 interface PaymentToken {
@@ -47,6 +50,7 @@ interface PaymentToken {
 
 interface PaymentRequestConfig {
   amount: string
+  environment: Environment
 }
 
 function getIsReadyToPayRequest() {
@@ -93,17 +97,17 @@ function getPaymentDataRequest(config: PaymentRequestConfig) {
 
 let paymentsClient: any = null
 
-function getGooglePaymentsClient() {
+function getGooglePaymentsClient(env: Environment) {
   if (paymentsClient === null) {
     paymentsClient = new google.payments.api.PaymentsClient({
-      environment: DEFAULT_CONFIG.environment,
+      environment: env,
     })
   }
   return paymentsClient
 }
 
-function onGooglePayLoaded(buttonOptions: ButtonOptions) {
-  paymentsClient = getGooglePaymentsClient()
+function onGooglePayLoaded(buttonOptions: ButtonOptions, env: Environment) {
+  paymentsClient = getGooglePaymentsClient(env)
   paymentsClient
     .isReadyToPay(getIsReadyToPayRequest())
     .then(function (response: IsReadyToPayResponse) {

--- a/lib/googlePay.ts
+++ b/lib/googlePay.ts
@@ -58,38 +58,6 @@ function getIsReadyToPayRequest() {
   return isReadyToPayRequest
 }
 
-const paymentDataRequest: PaymentDataRequest = {
-  apiVersion: 2,
-  apiVersionMinor: 0,
-  merchantInfo: {
-    merchantId: '12345678901234567890',
-    merchantName: 'Example Merchant',
-  },
-  allowedPaymentMethods: [
-    {
-      type: 'CARD',
-      parameters: {
-        allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
-        allowedCardNetworks: ['MASTERCARD', 'VISA'],
-      },
-      tokenizationSpecification: {
-        type: 'PAYMENT_GATEWAY',
-        parameters: {
-          gateway: 'checkoutltd',
-          gatewayMerchantId: 'YOUR_PUBLIC_KEY',
-        },
-      },
-    },
-  ],
-  transactionInfo: {
-    currencyCode: 'USD',
-    countryCode: 'US',
-    totalPriceStatus: 'FINAL',
-    totalPrice: '12.00',
-    checkoutOption: 'COMPLETE_IMMEDIATE_PURCHASE',
-  },
-}
-
 function getPaymentDataRequest(config: PaymentRequestConfig) {
   const amount =
     config.amount === null
@@ -155,5 +123,5 @@ export {
   getPaymentDataRequest,
   PaymentToken,
   PaymentRequestConfig,
-  DEFAULT_CONFIG
+  DEFAULT_CONFIG,
 }

--- a/lib/walletsApi.ts
+++ b/lib/walletsApi.ts
@@ -1,5 +1,6 @@
 import get from 'lodash/get'
 import axios from 'axios'
+import { v4 as uuidv4 } from 'uuid'
 
 import { getAPIHostname } from './apiTarget'
 
@@ -109,11 +110,11 @@ function getMasterWallet() {
  * @param {UUID} idempotencyKey
  */
 function convertToken(type: string, tokenData: Object) {
-  const url = '/v1/tokens'
+  const url = '/v1/paymenttokens'
   const payload = {
     type,
     tokenData,
-    idempotencyKey: '394dffd9-e992-4b86-b3f3-0a242a44db48',
+    idempotencyKey: uuidv4(),
   }
   const config = {
     headers: { 'Access-Control-Allow-Origin': '*' },

--- a/pages/debug/payments/digitalWallets/convertToken.vue
+++ b/pages/debug/payments/digitalWallets/convertToken.vue
@@ -114,8 +114,14 @@ export default class ConvertToken extends Vue {
     allowedPaymentMethods: [DEFAULT_CONFIG.allowedPaymentMethods],
   }
 
+  getGooglePayEnvironment() {
+    return getLive()
+      ? DEFAULT_CONFIG.environment.prod
+      : DEFAULT_CONFIG.environment.test
+  }
+
   mounted() {
-    onGooglePayLoaded(this.buttonOptions)
+    onGooglePayLoaded(this.buttonOptions, this.getGooglePayEnvironment())
   }
 
   onErrorSheetClosed() {
@@ -145,9 +151,11 @@ export default class ConvertToken extends Vue {
   }
 
   onGooglePayButtonClicked() {
-    const paymentsClient = getGooglePaymentsClient()
+    const env = this.getGooglePayEnvironment()
+    const paymentsClient = getGooglePaymentsClient(env)
     const paymentDataConfig: PaymentRequestConfig = {
       amount: this.formData.amount,
+      environment: env,
     }
     paymentsClient
       .loadPaymentData(getPaymentDataRequest(paymentDataConfig))

--- a/pages/debug/payments/digitalWallets/convertToken.vue
+++ b/pages/debug/payments/digitalWallets/convertToken.vue
@@ -74,7 +74,7 @@ import {
   getPaymentDataRequest,
   PaymentToken,
   PaymentRequestConfig,
-  DEFAULT_CONFIG
+  DEFAULT_CONFIG,
 } from '~/lib/googlePay'
 import ButtonOptions = google.payments.api.ButtonOptions
 import PaymentData = google.payments.api.PaymentData


### PR DESCRIPTION
This PR does the following:

1. Updates the convert tokens page to use the renamed endpoint `/paymenttokens`
2. Updates the code to use the `DEFAULT_CONFIG` object 
3. Creates an `onPaymentTypeChange()` method to manage the selected payment method