### PR TITLE
remove channel from token payment req

### DIFF
--- a/server-middleware/apiApplePay.ts
+++ b/server-middleware/apiApplePay.ts
@@ -121,7 +121,6 @@ export interface BasePaymentPayload {
     type: string
   }
   description: string
-  channel: string
   metadata: MetaData
 }
 
@@ -137,7 +136,6 @@ function createPaymentPayload(sourceId: string): BasePaymentPayload {
       type: 'token',
     },
     description: 'apple pay test',
-    channel: 'xxx',
     metadata: {
       phoneNumber: '+15103901174',
       email: 'wallet@circle.com',


### PR DESCRIPTION
channel needs to be a uuid, but it's not necessary atm, so just removed it