### PR TITLE
Add editable fields for tokens before api call

### DIFF
--- a/pages/debug/payments/digitalWallets/convertToken.vue
+++ b/pages/debug/payments/digitalWallets/convertToken.vue
@@ -38,6 +38,21 @@
               Signed Message: {{ formData.signedMessage }}
             </p>
           </v-card>
+          <v-text-field
+            v-if="tokensGenerated"
+            v-model="formData.protocolVersion"
+            label="Protocol Version"
+          />
+          <v-text-field
+            v-if="tokensGenerated"
+            v-model="formData.signature"
+            label="Signature"
+          />
+          <v-text-field
+            v-if="tokensGenerated"
+            v-model="formData.signedMessage"
+            label="Signed Message"
+          />
           <v-btn
             v-if="tokensGenerated"
             depressed


### PR DESCRIPTION
This PR adds fields to edit the token values before making the API call to /paymenttokens. This PR is for debugging on staging to determine the cause of an error with invalid parameters - it will be reverted after the bug is fixed.