### PR TITLE
Autogenerate tokens for applepay on smokebox/sandbox

### DIFF
--- a/lib/applePay.ts
+++ b/lib/applePay.ts
@@ -30,6 +30,17 @@ const DEFAULT_CONFIG = {
   },
 }
 
+interface PaymentToken {
+  version: string
+  data: string
+  signature: string
+  header: {
+    ephemeralPublicKey: string
+    publicKeyHash: string
+    transactionId: string
+  }
+}
+
 // Starts the Apple Pay session, registers event handlers
 function startApplePaySession(config: any, apiKey: string): void {
   const applePaySession: ApplePaySession = new ApplePaySession(6, config)
@@ -202,4 +213,4 @@ function applePayAvailable(): boolean {
   // canMakePaymentsWithActiveCard(merchantIdentifier: string):
 }
 
-export { startApplePaySession, DEFAULT_CONFIG, applePayAvailable }
+export { startApplePaySession, DEFAULT_CONFIG, applePayAvailable, PaymentToken }

--- a/pages/debug/payments/digitalWallets/convertToken.vue
+++ b/pages/debug/payments/digitalWallets/convertToken.vue
@@ -109,21 +109,22 @@ import { mapGetters } from 'vuex'
 import RequestInfo from '~/components/RequestInfo.vue'
 import ErrorSheet from '~/components/ErrorSheet.vue'
 import { getLive } from '~/lib/apiTarget'
+import { PaymentToken as ApplePayTokenData } from '~/lib/applePay'
 import {
-  onGooglePayLoaded,
+  DEFAULT_CONFIG,
   getGooglePaymentsClient,
   getPaymentDataRequest,
-  PaymentToken,
+  onGooglePayLoaded,
   PaymentRequestConfig,
-  DEFAULT_CONFIG,
+  PaymentToken as GooglePayTokenData,
 } from '~/lib/googlePay'
-import ButtonOptions = google.payments.api.ButtonOptions
-import PaymentData = google.payments.api.PaymentData
 import {
   checkoutKey,
   merchantId,
   merchantName,
 } from '~/server-middleware/googlePaySecrets'
+import ButtonOptions = google.payments.api.ButtonOptions
+import PaymentData = google.payments.api.PaymentData
 
 @Component({
   components: {
@@ -144,22 +145,8 @@ export default class ConvertToken extends Vue {
     amount: '0.00',
   }
 
-  googlePayTokenData = {
-    protocolVersion: '',
-    signature: '',
-    signedMessage: '',
-  }
-
-  applePayTokenData = {
-    version: '',
-    data: '',
-    signature: '',
-    header: {
-      ephemeralPublicKey: '',
-      publicKeyHash: '',
-      transactionId: '',
-    },
-  }
+  googlePayTokenData = {} as GooglePayTokenData
+  applePayTokenData = {} as ApplePayTokenData
 
   paymentType = ['Google Pay', 'Apple Pay']
   error = {}
@@ -222,9 +209,11 @@ export default class ConvertToken extends Vue {
       this.applePayTokenData.version = 'EC_v1'
       this.applePayTokenData.data = this.randomString()
       this.applePayTokenData.signature = this.randomString()
-      this.applePayTokenData.header.ephemeralPublicKey = this.randomString()
-      this.applePayTokenData.header.publicKeyHash = this.randomString()
-      this.applePayTokenData.header.transactionId = this.randomString()
+      this.applePayTokenData.header = {
+        ephemeralPublicKey: this.randomString(),
+        publicKeyHash: this.randomString(),
+        transactionId: this.randomString(),
+      }
       this.displayAppleTokens = true
     }
   }
@@ -244,7 +233,7 @@ export default class ConvertToken extends Vue {
       .then((paymentData: PaymentData) => {
         const paymentTokenString =
           paymentData.paymentMethodData.tokenizationData.token // payment token as JSON string
-        const paymentToken: PaymentToken = JSON.parse(paymentTokenString) // payment token as object with keys protocolVersion, signature, and signedMessage
+        const paymentToken: GooglePayTokenData = JSON.parse(paymentTokenString) // payment token as object with keys protocolVersion, signature, and signedMessage
         this.googlePayTokenData.protocolVersion = paymentToken.protocolVersion
         this.googlePayTokenData.signature = paymentToken.signature
         this.googlePayTokenData.signedMessage = paymentToken.signedMessage

--- a/pages/debug/payments/digitalWallets/convertToken.vue
+++ b/pages/debug/payments/digitalWallets/convertToken.vue
@@ -145,13 +145,13 @@ export default class ConvertToken extends Vue {
   }
 
   googlePayTokenData = {
-    protocolVersion: 'ECv1',
+    protocolVersion: '',
     signature: '',
     signedMessage: '',
   }
 
   applePayTokenData = {
-    version: 'EC_v1',
+    version: '',
     data: '',
     signature: '',
     header: {
@@ -214,10 +214,12 @@ export default class ConvertToken extends Vue {
   // autogenerate token info by assigning random strings to each field
   autogenerateTokens() {
     if (this.formData.type === 'Google Pay') {
+      this.googlePayTokenData.protocolVersion = 'ECv1'
       this.googlePayTokenData.signature = this.randomString()
       this.googlePayTokenData.signedMessage = this.randomString()
       this.displayGoogleTokens = true
     } else if (this.formData.type === 'Apple Pay') {
+      this.applePayTokenData.version = 'EC_v1'
       this.applePayTokenData.data = this.randomString()
       this.applePayTokenData.signature = this.randomString()
       this.applePayTokenData.header.ephemeralPublicKey = this.randomString()


### PR DESCRIPTION
This PR implements the autogenerate tokens feature for applepay on smokebox/sandbox, and enables the page to dynamically generate and display the correct tokens based on which payment type is selected.