### PR TITLE
Fix bug in applepay config params

### DIFF
--- a/lib/applePay.ts
+++ b/lib/applePay.ts
@@ -66,9 +66,6 @@ function startApplePaySessionBackendPay(
   apiKey: string,
   merchantType: string
 ): void {
-  inputConfig.shopName = config.total.label
-  inputConfig.lineItemType = config.total.type
-  inputConfig.amount = config.total.amount
   const applePaySession: ApplePaySession = new ApplePaySession(6, config)
   handleCommonApplePayEvents(applePaySession, merchantType)
   handleApplePayPaymentOnBackendEvent(applePaySession, apiKey)
@@ -80,6 +77,9 @@ function startApplePaySessionFrontendPay(
   tokenObject: PaymentToken,
   merchantType: string
 ): void {
+  inputConfig.shopName = config.total.label
+  inputConfig.lineItemType = config.total.type
+  inputConfig.amount = config.total.amount
   const applePaySession: ApplePaySession = new ApplePaySession(6, config)
   handleCommonApplePayEvents(applePaySession, merchantType)
   handleApplePayPaymentOnFrontendEvent(applePaySession, tokenObject)


### PR DESCRIPTION
This PR fixes a bug in using the apple pay parameters. The 3 lines of code below to save the inputted apple pay parameters were mistakenly in the backend method, rather than the frontend method where the parameters should actually be utilized