### PR TITLE
Fix applepay token display

### DIFF
--- a/pages/debug/payments/digitalWallets/convertToken.vue
+++ b/pages/debug/payments/digitalWallets/convertToken.vue
@@ -292,10 +292,6 @@ export default class ConvertToken extends Vue {
     }
   }
 
-  displayAppleTokensCallback = (): void => {
-    this.displayAppleTokens = true
-  }
-
   onApplePayButtonClicked() {
     startApplePaySessionFrontendPay(
       {
@@ -317,7 +313,9 @@ export default class ConvertToken extends Vue {
       },
       this.applePayTokenData,
       this.formData.merchantType,
-      this.displayAppleTokensCallback
+      (): void => {
+        this.displayAppleTokens = true
+      }
     )
   }
 


### PR DESCRIPTION
Final PR to fix the applepay tokens not being displayed properly. The function was not being passed properly when using `this.displayAppleTokensCallback` - need to pass the function directly as a parameter. 