### PR TITLE
Use applepay secrets and envvars

### DIFF
--- a/server-middleware/apiApplePay.ts
+++ b/server-middleware/apiApplePay.ts
@@ -7,15 +7,12 @@ import {
   partnershipMerchantIdentityKey,
   payfacMerchantIdentityCertificate,
   payfacMerchantIdentityKey,
+  partnershipMerchantId,
+  payfacMerchantId,
 } from './applePaySettings'
-import { apiHostname } from './serverEnv'
-import { getIsStaging } from '~/lib/apiTarget'
+import { apiHostname, domainName } from './serverEnv'
 
 const app = express()
-const MERCHANT_IDENTIFIER = 'merchant.bigtimetestmerchant.com'
-const DOMAIN_NAME = getIsStaging()
-  ? 'sample-staging.circle.com'
-  : 'sample.circle.com'
 const DISPLAY_NAME = 'Circle Apple Pay'
 
 // Steps:
@@ -45,8 +42,11 @@ app.post('/validate', (req, res) => {
       .post(
         appleUrl,
         {
-          merchantIdentifier: MERCHANT_IDENTIFIER,
-          domainName: DOMAIN_NAME,
+          merchantIdentifier:
+            merchantType === 'PayFac'
+              ? payfacMerchantId
+              : partnershipMerchantId,
+          domainName,
           displayName: DISPLAY_NAME,
         },
         {
@@ -85,9 +85,7 @@ export interface TokensPayload {
 }
 
 const instance = axios.create({
-  baseURL: getIsStaging()
-    ? 'https://api-staging.circle.com'
-    : 'https://api.circle.com',
+  baseURL: apiHostname,
 })
 
 function sendToken(token: ApplePayJS.ApplePayPaymentToken, apiKey: string) {

--- a/server-middleware/applePaySettings.ts
+++ b/server-middleware/applePaySettings.ts
@@ -1,26 +1,34 @@
-const applePaySecretsAreSet = !(
-  process.env.APPLE_PAY_PAYFAC_CERTIFICATE == null ||
-  process.env.APPLE_PAY_PAYFAC_PRIVATE_KEY == null ||
-  process.env.APPLE_PAY_PARTNERSHIP_CERTIFICATE == null ||
-  process.env.APPLE_PAY_PARTNERSHIP_PRIVATE_KEY == null
-)
+const payfacMerchantIdentityCertificate: string =
+  process.env.APPLE_PAY_PAYFAC_CERTIFICATE != null
+    ? process.env.APPLE_PAY_PAYFAC_CERTIFICATE!
+    : ''
+const payfacMerchantIdentityKey: string =
+  process.env.APPLE_PAY_PAYFAC_PRIVATE_KEY != null
+    ? process.env.APPLE_PAY_PAYFAC_PRIVATE_KEY!
+    : ''
+const partnershipMerchantIdentityCertificate: string =
+  process.env.APPLE_PAY_PARTNERSHIP_CERTIFICATE != null
+    ? process.env.APPLE_PAY_PARTNERSHIP_CERTIFICATE!
+    : ''
+const partnershipMerchantIdentityKey: string =
+  process.env.APPLE_PAY_PARTNERSHIP_PRIVATE_KEY != null
+    ? process.env.APPLE_PAY_PARTNERSHIP_PRIVATE_KEY!
+    : ''
 
-const payfacMerchantIdentityCertificate: string = applePaySecretsAreSet
-  ? process.env.APPLE_PAY_PAYFAC_CERTIFICATE!
-  : ''
-const payfacMerchantIdentityKey: string = applePaySecretsAreSet
-  ? process.env.APPLE_PAY_PAYFAC_PRIVATE_KEY!
-  : ''
-const partnershipMerchantIdentityCertificate: string = applePaySecretsAreSet
-  ? process.env.APPLE_PAY_PARTNERSHIP_CERTIFICATE!
-  : ''
-const partnershipMerchantIdentityKey: string = applePaySecretsAreSet
-  ? process.env.APPLE_PAY_PARTNERSHIP_PRIVATE_KEY!
-  : ''
+const domainValidation: string =
+  process.env.APPLE_PAY_DOMAIN_VERIFICATION != null
+    ? process.env.APPLE_PAY_DOMAIN_VERIFICATION!
+    : ''
 
-const domainValidation: string = applePaySecretsAreSet
-  ? process.env.APPLE_PAY_DOMAIN_VERIFICATION!
-  : ''
+const partnershipMerchantId: string =
+  process.env.APPLE_PAY_PARTNERSHIP_MERCHANT_ID != null
+    ? process.env.APPLE_PAY_PARTNERSHIP_MERCHANT_ID!
+    : ''
+
+const payfacMerchantId: string =
+  process.env.APPLE_PAY_PAYFAC_MERCHANT_ID != null
+    ? process.env.APPLE_PAY_PAYFAC_MERCHANT_ID!
+    : ''
 
 export {
   payfacMerchantIdentityCertificate,
@@ -28,4 +36,6 @@ export {
   domainValidation,
   partnershipMerchantIdentityCertificate,
   partnershipMerchantIdentityKey,
+  partnershipMerchantId,
+  payfacMerchantId,
 }

--- a/server-middleware/serverEnv.ts
+++ b/server-middleware/serverEnv.ts
@@ -6,6 +6,9 @@ api-sandbox.circle.com
 api-smokebox.circle.com
 */
 const apiHostname: string =
-  process.env.WALLETS_API == null ? process.env.WALLETS_API! : ''
+  process.env.WALLETS_API != null ? process.env.WALLETS_API! : ''
 
-export { apiHostname }
+const domainName: string =
+  process.env.DOMAIN_NAME != null ? process.env.DOMAIN_NAME! : ''
+
+export { apiHostname, domainName }


### PR DESCRIPTION
This PR updates apple pay to use merchantId and domain name from stored secrets