### PR TITLE
PR to return error details if apple pay validate fails 

### DIFF
--- a/server-middleware/apiApplePay.ts
+++ b/server-middleware/apiApplePay.ts
@@ -59,7 +59,12 @@ app.post('/validate', (req, res) => {
         res.send(a.data)
       })
       .catch((a) => {
-        res.send({ data: null })
+        res.send({
+          message: a.message,
+          responseStatus: a.response.status,
+          responseData: a.response.data,
+          responseHeaders: a.response.headers,
+        })
         console.log('Error occured during session validation')
         console.log(a.message)
         console.log(a.response.status)


### PR DESCRIPTION
PR to return the details of a session validation error for apple pay. Logs from the backend are not visible in the web browser console so this is necessary to debug why error is happening with session validation. 