### PR TITLE
Add support for Mock Sen

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -322,6 +322,10 @@ export default class DefaultLayoutsClass extends Vue {
       to: '/debug/payments/mocks/wire',
     },
     {
+      title: 'POST /mocks/payments/sen',
+      to: '/debug/payments/mocks/sen',
+    },
+    {
       title: 'POST /mocks/payments/sepa',
       to: '/debug/payments/mocks/sepa',
     },

--- a/lib/mocksApi.ts
+++ b/lib/mocksApi.ts
@@ -5,6 +5,7 @@ import { getAPIHostname } from './apiTarget'
 
 export interface CreateMockPushPaymentPayload {
   trackingRef: string
+  accountNumber: string
   amount: {
     amount: string
     currency: string
@@ -67,6 +68,15 @@ function createMockWirePayment(payload: CreateMockPushPaymentPayload) {
 }
 
 /**
+ * Trigger a mock sen payment
+ * @param {*} payload
+ */
+function createMockSenPayment(payload: CreateMockPushPaymentPayload) {
+  const url = '/v1/mocks/payments/sen'
+  return instance.post(url, payload)
+}
+
+/**
  * Trigger a mock sepa payment
  * @param {*} payload
  */
@@ -96,6 +106,7 @@ function createMockACHBankAccount(payload: CreateMockACHBankAccount) {
 export default {
   getInstance,
   createMockWirePayment,
+  createMockSenPayment,
   createMockSEPAPayment,
   createMockChargeback,
   createMockACHBankAccount,

--- a/pages/debug/payments/mocks/sen.vue
+++ b/pages/debug/payments/mocks/sen.vue
@@ -4,7 +4,16 @@
       <v-col cols="12" md="4">
         <v-form>
           <v-text-field v-model="formData.trackingRef" label="Tracking Ref" />
+          <v-text-field
+            v-model="formData.accountNumber"
+            label="Account Number"
+          />
           <v-text-field v-model="formData.amount" label="Amount" />
+          <v-select
+            v-model="formData.currency"
+            :items="currencyTypes"
+            label="Currency"
+          />
           <v-btn
             v-if="isSandbox"
             depressed
@@ -53,12 +62,15 @@ import { CreateMockPushPaymentPayload } from '@/lib/mocksApi'
     }),
   },
 })
-export default class CreateMockIncomingWireClass extends Vue {
+export default class CreateMockIncomingSenClass extends Vue {
   formData = {
     trackingRef: '',
+    accountNumber: '',
     amount: '0.00',
+    currency: '',
   }
 
+  currencyTypes = ['USD', 'EUR']
   isSandbox: Boolean = !getLive()
   required = [(v: string) => !!v || 'Field is required']
   error = {}
@@ -73,16 +85,16 @@ export default class CreateMockIncomingWireClass extends Vue {
     this.loading = true
     const amountDetail = {
       amount: this.formData.amount,
-      currency: 'USD',
+      currency: this.formData.currency,
     }
     const payload: CreateMockPushPaymentPayload = {
       trackingRef: this.formData.trackingRef,
-      accountNumber: '',
+      accountNumber: this.formData.accountNumber,
       amount: amountDetail,
     }
 
     try {
-      await this.$mocksApi.createMockWirePayment(payload)
+      await this.$mocksApi.createMockSenPayment(payload)
     } catch (error) {
       this.error = error
       this.showError = true

--- a/pages/debug/payments/mocks/sepa.vue
+++ b/pages/debug/payments/mocks/sepa.vue
@@ -77,6 +77,7 @@ export default class CreateMockSEPAClass extends Vue {
     }
     const payload: CreateMockPushPaymentPayload = {
       trackingRef: this.formData.trackingRef,
+      accountNumber: '',
       amount: amountDetail,
     }
 

--- a/plugins/mocksApi.ts
+++ b/plugins/mocksApi.ts
@@ -10,6 +10,7 @@ declare module 'vue/types/vue' {
       getInstance: any
       createMockChargeback: (payload: CreateMockChargebackPayload) => any
       createMockWirePayment: (payload: CreateMockPushPaymentPayload) => any
+      createMockSenPayment: (payload: CreateMockPushPaymentPayload) => any
       createMockSEPAPayment: (payload: CreateMockPushPaymentPayload) => any
       createMockACHBankAccount: (payload: CreateMockACHBankAccount) => any
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,7 +2134,7 @@
   dependencies:
     "@types/webpack" "^4"
 
-"@types/googlepay@^0.6.4":
+"@types/googlepay@0.6.4":
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/@types/googlepay/-/googlepay-0.6.4.tgz#e0b06ae1f12496c4fa43e52d35e76411dbbee135"
   integrity sha512-PTt/UCllzl8z5HmhymPpSj6uENZvVKZvCBYdDVmbBVJnLStitxtWrterAOQZkKGlqVdzxNXYeif5hOAMNMS5mw==


### PR DESCRIPTION
This PR is for adding support for Mock SEN push payment functionality. This adds a new page in sample-app to trigger a mock sen push payment.