### PR TITLE
[BRAAV-9510] - Add support for filtering through Payment Status for reversals

### DIFF
--- a/lib/paymentsApi.ts
+++ b/lib/paymentsApi.ts
@@ -191,6 +191,7 @@ function getBalance() {
 
 /**
  * Get reversals
+ * @param {String} status
  * @param {String} from
  * @param {String} to
  * @param {String} pageBefore
@@ -198,6 +199,7 @@ function getBalance() {
  * @param {String} pageSize
  */
 function getReversals(
+  status: string,
   from: string,
   to: string,
   pageBefore: string,
@@ -205,6 +207,7 @@ function getReversals(
   pageSize: string
 ) {
   const queryParams = {
+    status: nullIfEmpty(status),
     from: nullIfEmpty(from),
     to: nullIfEmpty(to),
     pageBefore: nullIfEmpty(pageBefore),

--- a/pages/debug/reversals/fetch.vue
+++ b/pages/debug/reversals/fetch.vue
@@ -4,11 +4,7 @@
       <v-col cols="12" md="4">
         <v-form>
           <header>Optional filter params:</header>
-          <v-select
-            v-model="formData.status"
-            :items="status"
-            label="Status"
-          />
+          <v-select v-model="formData.status" :items="status" label="Status" />
           <v-text-field v-model="formData.from" label="From" />
           <v-text-field v-model="formData.to" label="To" />
           <v-text-field v-model="formData.pageSize" label="PageSize" />

--- a/pages/debug/reversals/fetch.vue
+++ b/pages/debug/reversals/fetch.vue
@@ -70,14 +70,7 @@ export default class FetchReversalsClass extends Vue {
     pageAfter: '',
   }
 
-  status = [
-    'pending',
-    'action_required',
-    'confirmed',
-    'paid',
-    'failed',
-    'reversed',
-  ]
+  status = ['pending', 'action_required', 'confirmed', 'paid', 'failed']
 
   error = {}
   loading = false

--- a/pages/debug/reversals/fetch.vue
+++ b/pages/debug/reversals/fetch.vue
@@ -4,6 +4,11 @@
       <v-col cols="12" md="4">
         <v-form>
           <header>Optional filter params:</header>
+          <v-select
+            v-model="formData.status"
+            :items="status"
+            label="Status"
+          />
           <v-text-field v-model="formData.from" label="From" />
           <v-text-field v-model="formData.to" label="To" />
           <v-text-field v-model="formData.pageSize" label="PageSize" />
@@ -57,12 +62,22 @@ import ErrorSheet from '@/components/ErrorSheet.vue'
 export default class FetchReversalsClass extends Vue {
   // data
   formData = {
+    status: '',
     from: '',
     to: '',
     pageSize: '',
     pageBefore: '',
     pageAfter: '',
   }
+
+  status = [
+    'pending',
+    'action_required',
+    'confirmed',
+    'paid',
+    'failed',
+    'reversed',
+  ]
 
   error = {}
   loading = false
@@ -78,6 +93,7 @@ export default class FetchReversalsClass extends Vue {
     this.loading = true
     try {
       await this.$paymentsApi.getReversals(
+        this.formData.status,
         this.formData.from,
         this.formData.to,
         this.formData.pageBefore,


### PR DESCRIPTION
This PR adds support for filtering reversals based on status. Support for the filter is added in [this PR](https://github.com/circlefin/payment-processor/pull/1018) in the backend.