### PR TITLE
[BRAAV 8856] Update Google Pay Secrets logic

### DIFF
--- a/server-middleware/googlePaySecrets.ts
+++ b/server-middleware/googlePaySecrets.ts
@@ -1,19 +1,16 @@
-const googlePaySecretsAreSet = !(
-  process.env.GOOGLE_PAY_PAYFAC_MERCHANT_ID == null ||
-  process.env.GOOGLE_PAY_PAYFAC_MERCHANT_NAME == null ||
-  process.env.GOOGLE_PAY_PAYFAC_CHECKOUT_KEY == null
-)
+const merchantId: string =
+  process.env.GOOGLE_PAY_PAYFAC_MERCHANT_ID != null
+    ? process.env.GOOGLE_PAY_PAYFAC_MERCHANT_ID!
+    : ''
 
-const merchantId: string = googlePaySecretsAreSet
-  ? process.env.GOOGLE_PAY_PAYFAC_MERCHANT_ID!
-  : ''
+const merchantName: string =
+  process.env.GOOGLE_PAY_PAYFAC_MERCHANT_NAME != null
+    ? process.env.GOOGLE_PAY_PAYFAC_MERCHANT_NAME!
+    : ''
 
-const merchantName: string = googlePaySecretsAreSet
-  ? process.env.GOOGLE_PAY_PAYFAC_MERCHANT_NAME!
-  : ''
-
-const checkoutKey: string = googlePaySecretsAreSet
-  ? process.env.GOOGLE_PAY_PAYFAC_CHECKOUT_KEY!
-  : ''
+const checkoutKey: string =
+  process.env.GOOGLE_PAY_PAYFAC_CHECKOUT_KEY != null
+    ? process.env.GOOGLE_PAY_PAYFAC_CHECKOUT_KEY!
+    : ''
 
 export { merchantId, merchantName, checkoutKey }


### PR DESCRIPTION
Previously, if any of the three k8s secrets were null, all would be set to an empty string. This PR removes that logic.