### PR TITLE
[BRAAV 8856] Move google pay method to backend

### DIFF
--- a/lib/googlePay.ts
+++ b/lib/googlePay.ts
@@ -144,7 +144,9 @@ function onGooglePayClicked(
   amount: string,
   callback: (paymentData: PaymentData) => void
 ) {
-  const environment = DEFAULT_CONFIG.environment.prod
+  const environment = getIsStaging()
+    ? DEFAULT_CONFIG.environment.prod
+    : DEFAULT_CONFIG.environment.test
   const paymentsClient = getGooglePaymentsClient(environment)
   axios
     .get(BACKEND_URL_GET_VALUES, {

--- a/lib/googlePay.ts
+++ b/lib/googlePay.ts
@@ -6,6 +6,12 @@ import IsReadyToPayPaymentMethodSpecification = google.payments.api.IsReadyToPay
 import Environment = google.payments.api.Environment
 import PaymentMethodTokenizationSpecification = google.payments.api.PaymentMethodTokenizationSpecification
 import TransactionInfo = google.payments.api.TransactionInfo
+import {
+  checkoutKey,
+  merchantId,
+  merchantName,
+} from '~/server-middleware/googlePaySecrets'
+import PaymentData = google.payments.api.PaymentData
 
 const DEFAULT_CONFIG = {
   apiVersion: 2,
@@ -133,6 +139,29 @@ function onGooglePayLoaded(buttonOptions: ButtonOptions, env: Environment) {
     })
 }
 
+function onGooglePayClicked(
+  amount: string,
+  callback: (paymentData: PaymentData) => void
+) {
+  const environment = DEFAULT_CONFIG.environment.prod
+  const paymentsClient = getGooglePaymentsClient(environment)
+  const paymentDataConfig: PaymentRequestConfig = {
+    amount,
+    environment,
+    merchantId,
+    merchantName,
+    checkoutKey,
+  }
+  paymentsClient
+    .loadPaymentData(getPaymentDataRequest(paymentDataConfig))
+    .then((paymentData: PaymentData) => {
+      callback(paymentData)
+    })
+    .catch(function (err: any) {
+      console.error(err)
+    })
+}
+
 export {
   onGooglePayLoaded,
   getGooglePaymentsClient,
@@ -141,4 +170,5 @@ export {
   PaymentRequestConfig,
   DEFAULT_CONFIG,
   AUTOGEN_TOKEN_LENGTH,
+  onGooglePayClicked,
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -125,5 +125,9 @@ export default {
       path: '/.well-known',
       handler: '~/server-middleware/domainVerification.ts',
     },
+    {
+      path: '/api/googlepay',
+      handler: '~/server-middleware/apiGooglePay.ts',
+    },
   ],
 }

--- a/server-middleware/apiGooglePay.ts
+++ b/server-middleware/apiGooglePay.ts
@@ -3,6 +3,8 @@ import { checkoutKey, merchantId, merchantName } from './googlePaySecrets'
 
 const app = express()
 
+// This endpoint to expose the following values is to move forward with an internal milestone, but this is not the recommended approach for others implementing google pay
+// TODO: refactor google pay to initiate payment from the backend
 app.get('/values', (_, res) => {
   res.send({ merchantId, merchantName, checkoutKey })
 })

--- a/server-middleware/apiGooglePay.ts
+++ b/server-middleware/apiGooglePay.ts
@@ -1,0 +1,13 @@
+import express from 'express'
+import { checkoutKey, merchantId, merchantName } from './googlePaySecrets'
+
+const app = express()
+
+app.get('/values', (_, res) => {
+  res.send({ merchantId, merchantName, checkoutKey })
+})
+
+export default {
+  path: '/api/googlepay',
+  handler: app,
+}


### PR DESCRIPTION
In order to move forward with an internal milestone and validate that Google Pay is working on stg we need to implement and endpoint in the backend to serve the google pay values to the front end. We will be refactoring this code in the future to initiate the payment on the backend.