### PR TITLE
Temporarily use apple pay stored secret

### DIFF
--- a/server-middleware/apiGooglePay.ts
+++ b/server-middleware/apiGooglePay.ts
@@ -1,12 +1,13 @@
 import express from 'express'
-import { checkoutKey, merchantId, merchantName } from './googlePaySecrets'
+import { merchantId, merchantName } from './googlePaySecrets'
+import { payfacMerchantIdentityKey } from './applePaySettings'
 
 const app = express()
 
 // This endpoint to expose the following values is to move forward with an internal milestone, but this is not the recommended approach for others implementing google pay
 // TODO: refactor google pay to initiate payment from the backend
 app.get('/values', (_, res) => {
-  res.send({ merchantId, merchantName, checkoutKey })
+  res.send({ merchantId, merchantName, checkoutKey: payfacMerchantIdentityKey })
 })
 
 export default {


### PR DESCRIPTION
PR to temporarily use the applepay stored secret. (PR will be reverted when google pay secret is stored correctly)