### PR TITLE
Trim signedMessage in google pay payload

### DIFF
--- a/pages/debug/payments/digitalWallets/paymenttokens.vue
+++ b/pages/debug/payments/digitalWallets/paymenttokens.vue
@@ -305,7 +305,7 @@ export default class ConvertToken extends Vue {
       const paymentToken: GooglePayTokenData = JSON.parse(paymentTokenString) // payment token as object with keys protocolVersion, signature, and signedMessage
       this.googlePayTokenData.protocolVersion = paymentToken.protocolVersion
       this.googlePayTokenData.signature = paymentToken.signature
-      this.googlePayTokenData.signedMessage = paymentToken.signedMessage
+      this.googlePayTokenData.signedMessage = paymentToken.signedMessage.trim()
       this.displayGoogleTokens = true
     }
     onGooglePayClicked(this.formData.amount, callback)


### PR DESCRIPTION
Trim `signedMessage` to remove newline char at beginning of string