### PR TITLE
[Untracked] Fix googlepay signed message

### DIFF
--- a/pages/debug/payments/digitalWallets/paymenttokens.vue
+++ b/pages/debug/payments/digitalWallets/paymenttokens.vue
@@ -320,7 +320,7 @@ export default class ConvertToken extends Vue {
         tokenData = {
           protocolVersion: this.googlePayTokenData.protocolVersion,
           signature: this.googlePayTokenData.signature,
-          signedMessage: this.googlePayTokenData.signedMessage,
+          signedMessage: JSON.stringify(this.googlePayTokenData.signedMessage),
         }
         break
       case 'applepay':


### PR DESCRIPTION
Signed-off-by: Yves Liu <yves.liu@circle.com>

Google pay signed message should be a string. Need to serialize the object before sending it out.