### PR TITLE
Add form to edit token data for debugging

### DIFF
--- a/pages/debug/payments/digitalWallets/paymenttokens.vue
+++ b/pages/debug/payments/digitalWallets/paymenttokens.vue
@@ -90,6 +90,22 @@
               Header: {{ applePayTokenData.header }}
             </p>
           </v-card>
+          <!-- 3 text fields below for debugging only - to be removed once resolved -->
+          <v-text-field
+            v-if="displayGoogleTokens"
+            v-model="googlePayTokenData.protocolVersion"
+            label="Protocol Version"
+          />
+          <v-text-field
+            v-if="displayGoogleTokens"
+            v-model="googlePayTokenData.signature"
+            label="Signature"
+          />
+          <v-text-field
+            v-if="displayGoogleTokens"
+            v-model="googlePayTokenData.signedMessage"
+            label="Signed Message"
+          />
           <v-btn
             v-if="displayGoogleTokens || displayAppleTokens"
             depressed
@@ -306,8 +322,9 @@ export default class ConvertToken extends Vue {
       this.googlePayTokenData.protocolVersion = paymentToken.protocolVersion
       this.googlePayTokenData.signature = paymentToken.signature
       // Due to the parse earlier, the escaped double quotes were changed. need to change them back.
-      this.googlePayTokenData.signedMessage =
-        paymentToken.signedMessage.replace(/"/g, '\\"')
+      this.googlePayTokenData.signedMessage = paymentToken.signedMessage
+        .replaceAll('\\', '\\\\')
+        .replace(/"/g, '\\"')
       this.displayGoogleTokens = true
     }
     onGooglePayClicked(this.formData.amount, callback)


### PR DESCRIPTION
This PR adds an editable form (for google pay only, not apple pay) to edit token data fields for testing purposes - will be removed once debugging is complete.

<img width="1265" alt="Screen Shot 2022-07-06 at 1 08 29 PM" src="https://user-images.githubusercontent.com/38088920/177606769-74de0025-587b-4a97-8000-c0e2bd5d97d4.png">
