### PR TITLE
add new input field beneficiary account number to sample app mock wire

### DIFF
--- a/pages/debug/payments/mocks/wire.vue
+++ b/pages/debug/payments/mocks/wire.vue
@@ -4,6 +4,10 @@
       <v-col cols="12" md="4">
         <v-form>
           <v-text-field v-model="formData.trackingRef" label="Tracking Ref" />
+          <v-text-field
+            v-model="formData.accountNumber"
+            label="Account Number"
+          />
           <v-text-field v-model="formData.amount" label="Amount" />
           <v-btn
             v-if="isSandbox"
@@ -56,6 +60,7 @@ import { CreateMockPushPaymentPayload } from '@/lib/mocksApi'
 export default class CreateMockIncomingWireClass extends Vue {
   formData = {
     trackingRef: '',
+    accountNumber: '',
     amount: '0.00',
   }
 
@@ -78,7 +83,7 @@ export default class CreateMockIncomingWireClass extends Vue {
     const payload: CreateMockPushPaymentPayload = {
       trackingRef: this.formData.trackingRef,
       beneficiaryBank: {
-        accountNumber: '',
+        accountNumber: this.formData.accountNumber,
       },
       amount: amountDetail,
     }


### PR DESCRIPTION
We would need to add a new input field - Beneficiary account number to POST /mocks/payments/wire in sample app