### PR TITLE
Make identities truly optional for payout

### DIFF
--- a/pages/debug/beta/payouts/create.vue
+++ b/pages/debug/beta/payouts/create.vue
@@ -192,7 +192,6 @@ export default class CreatePayoutClass extends Vue {
       this.formData.identityAddressDistrict ||
       this.formData.identityAddressPostalCode ||
       this.formData.identityAddressCountry ||
-      this.formData.identityType ||
       this.formData.identityName
     )
   }
@@ -217,6 +216,18 @@ export default class CreatePayoutClass extends Vue {
       ? Array.from(this.supportedCryptoPayoutCurrencyPairs.keys())[0]
       : this.supportedFiatPayoutCurrencies[0]
     this.onCurrencyChange()
+    this.resetIdentities()
+  }
+
+  resetIdentities() {
+    // reset all identity fields
+    this.formData.identityAddressLine1 = ''
+    this.formData.identityAddressLine2 = ''
+    this.formData.identityAddressCountry = ''
+    this.formData.identityAddressCity = ''
+    this.formData.identityAddressDistrict = ''
+    this.formData.identityName = ''
+    this.formData.identityAddressPostalCode = ''
   }
 
   onErrorSheetClosed() {

--- a/pages/debug/beta/payouts/create.vue
+++ b/pages/debug/beta/payouts/create.vue
@@ -184,14 +184,15 @@ export default class CreatePayoutClass extends Vue {
     return this.blockchainDestinationTypes.has(this.formData.destinationType)
   }
 
-  hasValidIdentities() {
+  hasIdentity() {
     return (
-      this.formData.identityAddressLine1 &&
-      this.formData.identityAddressCity &&
-      this.formData.identityAddressDistrict &&
-      this.formData.identityAddressPostalCode &&
-      this.formData.identityAddressCountry &&
-      this.formData.identityType &&
+      this.formData.identityAddressLine1 ||
+      this.formData.identityAddressLine2 ||
+      this.formData.identityAddressCity ||
+      this.formData.identityAddressDistrict ||
+      this.formData.identityAddressPostalCode ||
+      this.formData.identityAddressCountry ||
+      this.formData.identityType ||
       this.formData.identityName
     )
   }
@@ -246,7 +247,7 @@ export default class CreatePayoutClass extends Vue {
       addresses: [identityAddressObject],
     }
 
-    const identities = this.hasValidIdentities() && {
+    const identities = this.hasIdentity() && {
       identities: [identityObject],
     }
 


### PR DESCRIPTION
This PR fixes the current bug on identities.
We will only send identities to BE if there is one field of identity field, otherwise it won't be attached to source.
Also if no source ID is provided, we shouldn't attach source to the payload.