### PR TITLE
Create APIs for Checkout Sessions

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -188,6 +188,32 @@
             </v-list-item-content>
           </v-list-item>
         </v-list-group>
+
+        <v-list-group>
+          <template #activator>
+            <v-list-item-title>Checkout Sessions APIs</v-list-item-title>
+          </template>
+
+          <v-list-item to="/debug/checkoutSessions" router exact>
+            <v-list-item-content>
+              <v-list-item-title class="list-items pl-2">
+                Overview
+              </v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+
+          <v-list-item
+            v-for="(item, i) in checkoutSessionsLinks"
+            :key="`checkoutSessionsLinks-${i}`"
+            :to="item.to"
+            router
+            exact
+          >
+            <v-list-item-content>
+              <v-list-item-title class="list-items pl-2" v-text="item.title" />
+            </v-list-item-content>
+          </v-list-item>
+        </v-list-group>
       </v-list>
     </v-navigation-drawer>
     <v-app-bar clipped-left fixed app dark color="primary" dense>
@@ -690,6 +716,21 @@ export default class DefaultLayoutsClass extends Vue {
     {
       title: 'GET /transfers/{id}',
       to: '/debug/wallets/transfers/details',
+    },
+  ]
+
+  checkoutSessionsLinks = [
+    {
+      title: 'POST /checkoutSessions',
+      to: '/debug/checkoutSessions/create',
+    },
+    {
+      title: 'GET /checkoutSessions/{id}',
+      to: '/debug/checkoutSessions/details',
+    },
+    {
+      title: 'POST /checkoutSessions/{id}/extend',
+      to: '/debug/checkoutSessions/extend',
     },
   ]
 

--- a/lib/checkoutSessionsApi.ts
+++ b/lib/checkoutSessionsApi.ts
@@ -1,0 +1,84 @@
+import get from 'lodash/get'
+import axios from 'axios'
+
+import { getAPIHostname } from './apiTarget'
+
+export interface CreateCheckoutSessionPayload {
+  amount: {
+    amount: string
+    currency: string
+  }
+  successUrl: string
+}
+
+export interface ExtendCheckoutSessionPayload {
+  extendTime: number
+}
+
+const instance = axios.create({
+  baseURL: getAPIHostname(),
+})
+
+/**
+ * Global error handler:
+ * Intercepts all axios responses and maps
+ * to errorHandler object
+ */
+instance.interceptors.response.use(
+  function (response) {
+    if (get(response, 'data.data')) {
+      return response.data.data
+    }
+    return response
+  },
+  function (error) {
+    let response = get(error, 'response')
+    if (!response) {
+      response = error.toJSON()
+    }
+    return Promise.reject(response)
+  }
+)
+
+/** Returns the axios instance */
+function getInstance() {
+  return instance
+}
+
+/**
+ * Create a checkout session
+ * @param {*} payload
+ */
+function createCheckoutSession(payload: CreateCheckoutSessionPayload) {
+  const url = '/v1/checkoutSessions'
+  return instance.post(url, payload)
+}
+
+/**
+ * Expire a checkout session
+ * @param checkoutSessionId checkout session id
+ * @param payload payload
+ */
+function extendCheckoutSession(
+  checkoutSessionId: string,
+  payload: ExtendCheckoutSessionPayload
+) {
+  const url = `/v1/checkoutSessions/${checkoutSessionId}/extend`
+  return instance.post(url, payload)
+}
+
+/**
+ * Get checkout session by ID
+ * @param {String} checkoutSessionId
+ */
+function getCheckoutSessionById(checkoutSessionId: string) {
+  const url = `/v1/checkoutSessions/${checkoutSessionId}`
+  return instance.get(url)
+}
+
+export default {
+  getInstance,
+  getCheckoutSessionById,
+  createCheckoutSession,
+  extendCheckoutSession,
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -66,6 +66,7 @@ export default {
     '~/plugins/businessAccount/payoutsApi',
     '~/plugins/businessAccount/transfersApi',
     '~/plugins/cryptoPaymentMetadataApi',
+    '~/plugins/checkoutSessionsApi',
   ],
   /*
    ** Nuxt.js dev-modules

--- a/pages/debug/checkoutSessions/create.vue
+++ b/pages/debug/checkoutSessions/create.vue
@@ -1,0 +1,117 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="formData.successUrl"
+            label="Success URL(Optional)"
+          />
+
+          <v-text-field
+            v-model="formData.amount"
+            label="Checkout Session Amount"
+          />
+
+          <v-select
+            v-model="formData.currency"
+            :items="supportedCurrencies"
+            label="Checkout Session Currency"
+            @change="onCurrencyChange"
+          />
+
+          <v-btn
+            v-if="currencySelected"
+            depressed
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+import { CreateCheckoutSessionPayload } from '~/lib/checkoutSessionsApi'
+
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+      isMarketplace: 'isMarketplace',
+    }),
+  },
+})
+export default class CreateCheckoutSessionClass extends Vue {
+  formData = {
+    successUrl: '',
+    amount: '0.00',
+    currency: '',
+  }
+
+  required = [(v: string) => !!v || 'Field is required']
+  error = {}
+  loading = false
+  showError = false
+  supportedCurrencies = ['USD', 'ETH', 'BTC']
+  currencySelected = false
+
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  onCurrencyChange() {
+    this.currencySelected = true
+  }
+
+  async makeApiCall() {
+    this.loading = true
+    const amountDetail = {
+      amount: this.formData.amount,
+      currency: this.formData.currency,
+    }
+    const successUrl = this.formData.successUrl
+
+    const payload: CreateCheckoutSessionPayload = {
+      amount: amountDetail,
+      successUrl,
+    }
+    try {
+      await this.$checkoutSessionsApi.createCheckoutSession(payload)
+    } catch (error) {
+      this.error = error
+      this.showError = true
+    } finally {
+      this.loading = false
+    }
+  }
+}
+</script>

--- a/pages/debug/checkoutSessions/details.vue
+++ b/pages/debug/checkoutSessions/details.vue
@@ -1,0 +1,87 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="formData.checkoutSessionId"
+            label="Checkout Session ID"
+          />
+          <v-btn
+            depressed
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+    }),
+  },
+})
+export default class FetchPaymentIntentDetailsClass extends Vue {
+  // data
+  formData = {
+    checkoutSessionId: '',
+  }
+
+  required = [(v: string) => !!v || 'Field is required']
+  error = {}
+  loading = false
+  showError = false
+
+  // methods
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  async makeApiCall() {
+    this.loading = true
+    try {
+      await this.$checkoutSessionsApi.getCheckoutSessionById(
+        this.formData.checkoutSessionId
+      )
+    } catch (error) {
+      this.error = error
+      this.showError = true
+    } finally {
+      this.loading = false
+    }
+  }
+}
+</script>

--- a/pages/debug/checkoutSessions/details.vue
+++ b/pages/debug/checkoutSessions/details.vue
@@ -53,7 +53,7 @@ import ErrorSheet from '@/components/ErrorSheet.vue'
     }),
   },
 })
-export default class FetchPaymentIntentDetailsClass extends Vue {
+export default class FetchCheckoutSessionDetailsClass extends Vue {
   // data
   formData = {
     checkoutSessionId: '',

--- a/pages/debug/checkoutSessions/extend.vue
+++ b/pages/debug/checkoutSessions/extend.vue
@@ -77,9 +77,9 @@ export default class ExtendCheckoutSessionClass extends Vue {
 
   async makeApiCall() {
     this.loading = true
-    const extendTime = this.formData.extendTime
+    const extendTime = Number(this.formData.extendTime)
     const payload: ExtendCheckoutSessionPayload = {
-      extendTime: Number(),
+      extendTime,
     }
     try {
       await this.$checkoutSessionsApi.extendCheckoutSession(

--- a/pages/debug/checkoutSessions/extend.vue
+++ b/pages/debug/checkoutSessions/extend.vue
@@ -1,0 +1,97 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="formData.checkoutSessionId"
+            label="Checkout Session ID"
+          />
+          <v-text-field
+            v-model="formData.extendTime"
+            label="Time To Extend(Optional)"
+          />
+          <v-btn
+            depressed
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+import { ExtendCheckoutSessionPayload } from '~/lib/checkoutSessionsApi'
+
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+    }),
+  },
+})
+export default class ExtendCheckoutSessionClass extends Vue {
+  // data
+  formData = {
+    checkoutSessionId: '',
+    extendTime: null,
+  }
+
+  required = [(v: string) => !!v || 'Field is required']
+  error = {}
+  loading = false
+  showError = false
+
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  async makeApiCall() {
+    this.loading = true
+    const extendTime = this.formData.extendTime
+    const payload: ExtendCheckoutSessionPayload = {
+      extendTime: Number(),
+    }
+    try {
+      await this.$checkoutSessionsApi.extendCheckoutSession(
+        this.formData.checkoutSessionId,
+        extendTime ? payload : null
+      )
+    } catch (error) {
+      this.error = error
+      this.showError = true
+    } finally {
+      this.loading = false
+    }
+  }
+}
+</script>

--- a/pages/debug/checkoutSessions/index.vue
+++ b/pages/debug/checkoutSessions/index.vue
@@ -1,0 +1,57 @@
+<template>
+  <v-layout>
+    <v-flex>
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h1 class="headline">API viewer</h1>
+
+        <p class="mt-6">
+          Make api calls using your private api key. Explore payload and
+          response data in the UI.
+        </p>
+        <p>
+          Please use the settings panel on the right to configure your payments
+          api key.
+        </p>
+      </v-card>
+
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h2 class="title">Checkout Sessions endpoints</h2>
+        <span class="caption">Requires: api key</span>
+        <br /><br />
+        <p>Api endpoints to manage checkout sessions.</p>
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/checkoutSessions/create"
+            >Create a checkout session
+          </a>
+        </p>
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/checkoutSessions/extend">
+            Extend a checkout session
+          </a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/checkoutSessions/details">
+            Get checkout session details by id
+          </a>
+        </p>
+      </v-card>
+    </v-flex>
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+
+@Component({
+  computed: {
+    ...mapGetters({
+      isMarketplace: 'isMarketplace',
+    }),
+  },
+})
+export default class CheckoutSessionsIndexClass extends Vue {}
+</script>

--- a/plugins/checkoutSessionsApi.ts
+++ b/plugins/checkoutSessionsApi.ts
@@ -1,0 +1,45 @@
+import checkoutSessionsAPI, {
+  CreateCheckoutSessionPayload,
+} from '@/lib/checkoutSessionsApi'
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $checkoutSessionsApi: {
+      getCheckoutSessionById: any
+      createCheckoutSession: (payload: CreateCheckoutSessionPayload) => any
+      extendCheckoutSession: (checkoutSessionId: string, payload: any) => any
+    }
+  }
+}
+
+export default ({ store }: any, inject: any) => {
+  const instance = checkoutSessionsAPI.getInstance()
+
+  instance.interceptors.request.use(
+    function (config) {
+      store.commit('CLEAR_REQUEST_DATA')
+      store.commit('SET_REQUEST_URL', `${config.baseURL}${config.url}`)
+      store.commit('SET_REQUEST_PAYLOAD', config.data)
+
+      if (store.state.bearerToken) {
+        config.headers = { Authorization: `Bearer ${store.state.bearerToken}` }
+      }
+      return config
+    },
+    function (error) {
+      return Promise.reject(error)
+    }
+  )
+
+  instance.interceptors.response.use(
+    function (response) {
+      store.commit('SET_RESPONSE', response)
+      return response
+    },
+    function (error) {
+      return Promise.reject(error)
+    }
+  )
+
+  inject('checkoutSessionsApi', checkoutSessionsAPI)
+}


### PR DESCRIPTION
Adding endpoints for checkout session releasing
GET `/v1/checkoutSessions/:id` to get a `checkout session`
POST `/v1/checkoutSessions` to create a `checkout session`
POST `/v1/checkoutSessions/:id/extend` to extend a `checkout session`


![Recording 2022-11-15 at 16 39 08](https://user-images.githubusercontent.com/104461816/202030749-de93a3cd-747d-45e1-bdfd-9162e14536b0.gif)

ref doc: https://docs.google.com/document/d/1MPPUBkaTpWOjHcZE16cxD26Kx4Fm9t7BKvFUjFBUeRA/edit#heading=h.6pt2ia8sm9o0

https://circlepay.atlassian.net/browse/PAYEX-358