### PR TITLE
Add crypto refund creation page

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -680,6 +680,10 @@ export default class DefaultLayoutsClass extends Vue {
       title: 'POST /paymentIntents/{id}/expire',
       to: '/debug/paymentIntents/expire',
     },
+    {
+      title: 'POST /paymentIntents/{id}/refund',
+      to: '/debug/paymentIntents/createCryptoRefund',
+    },
   ]
 
   digitalDollarAccountsLinks = [

--- a/lib/paymentIntentsApi.ts
+++ b/lib/paymentIntentsApi.ts
@@ -19,6 +19,21 @@ export interface CreatePaymentIntentPayload {
   expiresOn: string
 }
 
+export interface CreateCryptoRefundPayload {
+  idempotencyKey: string
+  destination: {
+    address: string
+    chain: string
+  }
+  amount: {
+    currency: string
+  }
+  toAmount: {
+    amount: string
+    currency: string
+  }
+}
+
 const instance = axios.create({
   baseURL: getAPIHostname(),
 })
@@ -84,6 +99,19 @@ function getPaymentIntentById(paymentIntentId: string) {
 }
 
 /**
+ * Create crypto refund
+ * @param {String} paymentIntentId
+ * @param {*} payload
+ */
+function createCryptoRefund(
+  paymentIntentId: string,
+  payload: CreateCryptoRefundPayload
+) {
+  const url = `/v1/paymentIntents/${paymentIntentId}/refund`
+  return instance.post(url, payload)
+}
+
+/**
  * Get payment intents
  * @param {String} status
  * @param {String} context
@@ -121,4 +149,5 @@ export default {
   getPaymentIntentById,
   createPaymentIntent,
   expirePaymentIntent,
+  createCryptoRefund,
 }

--- a/pages/debug/paymentIntents/createCryptoRefund.vue
+++ b/pages/debug/paymentIntents/createCryptoRefund.vue
@@ -36,10 +36,7 @@
             label="Identity Type"
           />
 
-          <v-text-field
-            v-model="formData.identityName"
-            label="Identity Name"
-          />
+          <v-text-field v-model="formData.identityName" label="Identity Name" />
 
           <v-text-field
             v-model="formData.identityAddressLine1"

--- a/pages/debug/paymentIntents/createCryptoRefund.vue
+++ b/pages/debug/paymentIntents/createCryptoRefund.vue
@@ -1,0 +1,215 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="formData.paymentIntentId"
+            label="Payment Intent ID"
+          />
+
+          <v-text-field
+            v-model="formData.fromCurrency"
+            label="Source Currency"
+          />
+
+          <v-text-field v-model="formData.toAmount" label="Refund Amount" />
+
+          <v-text-field v-model="formData.toCurrency" label="Refund Currency" />
+
+          <v-text-field
+            v-model="formData.address"
+            label="Destination Address"
+          />
+
+          <v-text-field
+            v-model="formData.blockchain"
+            label="Destination Blockchain"
+          />
+
+          <header>Optional Identity:</header>
+          <br />
+
+          <v-select
+            v-model="formData.identityType"
+            :items="identityTypes"
+            label="Identity Type"
+          />
+
+          <v-text-field
+            v-model="formData.identityName"
+            label="Identity Name"
+          />
+
+          <v-text-field
+            v-model="formData.identityAddressLine1"
+            label="Identity Address Line 1"
+          />
+
+          <v-text-field
+            v-model="formData.identityAddressLine2"
+            label="Identity Address Line 2"
+          />
+
+          <v-text-field
+            v-model="formData.identityAddressCity"
+            label="Identity Address City"
+          />
+
+          <v-text-field
+            v-model="formData.identityAddressDistrict"
+            label="Identity Address District"
+          />
+
+          <v-text-field
+            v-model="formData.identityAddressPostalCode"
+            label="Identity Address Postal Code"
+          />
+
+          <v-text-field
+            v-model="formData.identityAddressCountry"
+            label="Identity Address Country"
+          />
+
+          <v-btn
+            v-if="!!formData.paymentIntentId"
+            depressed
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import { v4 as uuidv4 } from 'uuid'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+import { CreateCryptoRefundPayload } from '@/lib/paymentIntentsApi'
+
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+      isMarketplace: 'isMarketplace',
+    }),
+  },
+})
+export default class CreatePaymentIntentClass extends Vue {
+  formData = {
+    paymentIntentId: '',
+    idempotencyKey: '',
+    fromCurrency: '',
+    toAmount: '',
+    toCurrency: '',
+    blockchain: '',
+    address: '',
+    identityType: 'individual', // Default to individual for identity type
+    identityName: '',
+    identityAddressLine1: '',
+    identityAddressLine2: '',
+    identityAddressCity: '',
+    identityAddressDistrict: '',
+    identityAddressPostalCode: '',
+    identityAddressCountry: '',
+  }
+
+  required = [(v: string) => !!v || 'Field is required']
+  error = {}
+  loading = false
+  showError = false
+  identityTypes = ['individual', 'business']
+
+  hasIdentity() {
+    return (
+      this.formData.identityAddressLine1 ||
+      this.formData.identityAddressLine2 ||
+      this.formData.identityAddressCity ||
+      this.formData.identityAddressDistrict ||
+      this.formData.identityAddressPostalCode ||
+      this.formData.identityAddressCountry ||
+      this.formData.identityName
+    )
+  }
+
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  async makeApiCall() {
+    this.loading = true
+    const fromAmountDetail = {
+      currency: this.formData.fromCurrency,
+    }
+    const toAmountDetail = {
+      amount: this.formData.toAmount,
+      currency: this.formData.toCurrency,
+    }
+    const identityAddressObject = {
+      line1: this.formData.identityAddressLine1,
+      line2: this.formData.identityAddressLine2,
+      city: this.formData.identityAddressCity,
+      district: this.formData.identityAddressDistrict,
+      postalCode: this.formData.identityAddressPostalCode,
+      country: this.formData.identityAddressCountry,
+    }
+    const identityObject = {
+      type: this.formData.identityType,
+      name: this.formData.identityName,
+      addresses: [identityAddressObject],
+    }
+    const identities = this.hasIdentity() && {
+      identities: [identityObject],
+    }
+
+    const payload: CreateCryptoRefundPayload = {
+      idempotencyKey: uuidv4(),
+      destination: {
+        chain: this.formData.blockchain,
+        address: this.formData.address,
+      },
+      amount: fromAmountDetail,
+      toAmount: toAmountDetail,
+      ...identities,
+    }
+    try {
+      await this.$paymentIntentsApi.createCryptoRefund(
+        this.formData.paymentIntentId,
+        payload
+      )
+    } catch (error) {
+      this.error = error
+      this.showError = true
+    } finally {
+      this.loading = false
+    }
+  }
+}
+</script>

--- a/pages/debug/paymentIntents/index.vue
+++ b/pages/debug/paymentIntents/index.vue
@@ -37,6 +37,12 @@
             Get payment intent details by id
           </a>
         </p>
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/paymentIntents/createCryptoRefund">
+            Create crypto refund
+          </a>
+        </p>
       </v-card>
     </v-flex>
   </v-layout>

--- a/plugins/paymentIntentsApi.ts
+++ b/plugins/paymentIntentsApi.ts
@@ -9,6 +9,7 @@ declare module 'vue/types/vue' {
       getPaymentIntentById: any
       createPaymentIntent: (payload: CreatePaymentIntentPayload) => any
       expirePaymentIntent: any
+      createCryptoRefund: any
       getInstance: any
     }
   }


### PR DESCRIPTION
This PR adds the crypto refund creation page in sample-app.
This is the alpha-version, so it is kept as simple as possible.

<img width="1088" alt="Screen Shot 2022-11-16 at 3 11 24 PM" src="https://user-images.githubusercontent.com/97554856/202284170-73aa0c01-7680-4fc4-8047-c3beb2bcdfec.png">

<img width="924" alt="Screen Shot 2022-11-16 at 3 11 53 PM" src="https://user-images.githubusercontent.com/97554856/202284266-7ed3580a-363e-4d04-b000-dfd3f118c74e.png">
