### PR TITLE
Fix success url empty string, make it optional

### DIFF
--- a/lib/checkoutSessionsApi.ts
+++ b/lib/checkoutSessionsApi.ts
@@ -8,7 +8,7 @@ export interface CreateCheckoutSessionPayload {
     amount: string
     currency: string
   }
-  successUrl: string
+  successUrl?: string
 }
 
 export interface ExtendCheckoutSessionPayload {

--- a/pages/debug/checkoutSessions/create.vue
+++ b/pages/debug/checkoutSessions/create.vue
@@ -71,7 +71,7 @@ import { CreateCheckoutSessionPayload } from '~/lib/checkoutSessionsApi'
 })
 export default class CreateCheckoutSessionClass extends Vue {
   formData = {
-    successUrl: '',
+    successUrl: null,
     amount: '0.00',
     currency: '',
   }
@@ -102,8 +102,11 @@ export default class CreateCheckoutSessionClass extends Vue {
 
     const payload: CreateCheckoutSessionPayload = {
       amount: amountDetail,
-      successUrl,
     }
+    if (successUrl) {
+      payload.successUrl = successUrl
+    }
+
     try {
       await this.$checkoutSessionsApi.createCheckoutSession(payload)
     } catch (error) {


### PR DESCRIPTION
successUrl was using an empty string represents optional, then the backend added url validation.
Now don't add it to payload if it's empty