### PR TITLE
[PAYM-988] add Fee quote field for creating crypto payments

### DIFF
--- a/lib/cryptoPaymentsApi.ts
+++ b/lib/cryptoPaymentsApi.ts
@@ -30,6 +30,7 @@ export interface CreateCryptoPaymentPayload {
     chain: string
   }
   protocolMetadata: TransferWithAuthorizationMetadata
+  quoteId: string
 }
 
 const instance = axios.create({

--- a/pages/debug/payments/crypto/create.vue
+++ b/pages/debug/payments/crypto/create.vue
@@ -36,6 +36,11 @@
             label="Destination Chain"
           />
 
+          <v-text-field
+            v-model="formData.feeQuoteId"
+            label="Fee Quote Id (Only for End User Pay)"
+          />
+
           <v-select
             v-model="formData.protocolType"
             :items="protocolType"
@@ -124,6 +129,7 @@ export default class CreatePaymentClass extends Vue {
     sourceType: 'blockchain',
     destinationAddress: '',
     destinationChain: '',
+    feeQuoteId: '',
     protocolType: 'TransferWithAuthorization',
     validAfter: '0',
     validBefore: '',
@@ -173,6 +179,7 @@ export default class CreatePaymentClass extends Vue {
       source: sourceDetails,
       destination: destinationDetails,
       protocolMetadata: protocolMetadataDetails,
+      quoteId: this.formData.feeQuoteId,
     }
 
     try {


### PR DESCRIPTION
For https://github.com/circlefin/payment-processor/pull/1595, we introduced a new optional field QuoteId in the create crypto payment endpoint. Update the sample app for easier testing

<img width="863" alt="Screen Shot 2023-01-24 at 3 18 22 PM" src="https://user-images.githubusercontent.com/109987517/214442586-d108746e-9dc4-4c28-ae6d-e81e4f55428a.png">
