### PR TITLE
[PAYM-1053] Send remaining fields from presign page to create payment page

### DIFF
--- a/pages/debug/payments/crypto/create.vue
+++ b/pages/debug/payments/crypto/create.vue
@@ -120,6 +120,7 @@ import { CreateCryptoPaymentPayload } from '~/lib/cryptoPaymentsApi'
     }),
   },
 })
+
 export default class CreatePaymentClass extends Vue {
   formData = {
     paymentIntentId: (this.$route.query.paymentIntentId as string) || '',
@@ -135,7 +136,7 @@ export default class CreatePaymentClass extends Vue {
     validAfter: (this.$route.query.validAfter as string) || '0',
     validBefore: (this.$route.query.validBefore as string) || '',
     metaTxNonce: (this.$route.query.metaTxNonce as string) || '',
-    rawSignature: (this.$route.query.signature as string) || '',
+    rawSignature: (this.$route.query.rawSignature as string) || '',
   }
 
   sourceType = ['blockchain']

--- a/pages/debug/payments/crypto/create.vue
+++ b/pages/debug/payments/crypto/create.vue
@@ -125,11 +125,11 @@ export default class CreatePaymentClass extends Vue {
     paymentIntentId: (this.$route.query.paymentIntentId as string) || '',
     amount: (this.$route.query.amount as string) || '0.00',
     currency: (this.$route.query.currency as string) || 'USD',
-    sourceAddress: '',
+    sourceAddress: (this.$route.query.sourceAddress as string) || '',
     sourceType: 'blockchain',
     destinationAddress: (this.$route.query.destinationAddress as string) || '',
     destinationChain: 'ETH',
-    feeQuoteId: '',
+    feeQuoteId: (this.$route.query.feeQuoteId as string) || '',
     protocolType:
       (this.$route.query.protocolType as string) || 'TransferWithAuthorization',
     validAfter: (this.$route.query.validAfter as string) || '0',

--- a/pages/debug/payments/crypto/create.vue
+++ b/pages/debug/payments/crypto/create.vue
@@ -38,7 +38,7 @@
 
           <v-text-field
             v-model="formData.feeQuoteId"
-            label="Fee Quote Id (Only for End User Pay)"
+            label="Fee Quote UUID (Required if network fees paid by end user)"
           />
 
           <v-select

--- a/pages/debug/payments/crypto/create.vue
+++ b/pages/debug/payments/crypto/create.vue
@@ -120,7 +120,6 @@ import { CreateCryptoPaymentPayload } from '~/lib/cryptoPaymentsApi'
     }),
   },
 })
-
 export default class CreatePaymentClass extends Vue {
   formData = {
     paymentIntentId: (this.$route.query.paymentIntentId as string) || '',

--- a/pages/debug/payments/crypto/presign.vue
+++ b/pages/debug/payments/crypto/presign.vue
@@ -41,17 +41,7 @@
               slot="append"
               :to="{
                 path: '/debug/payments/crypto/create',
-                query: {
-                  paymentIntentId: formData.paymentIntentId,
-                  destinationAddress: getTypedData().message.to,
-                  amount: getTypedData().totalAmount.amount,
-                  currency: getTypedData().totalAmount.currency,
-                  protocolType: getTypedData().totalAmount.primaryType,
-                  signature: formData.rawSignature,
-                  validAfter: getTypedData().message.validAfter,
-                  metaTxNonce: getTypedData().message.nonce,
-                  validBefore: getTypedData().message.validBefore,
-                },
+                query: getCreatePaymentQueryParams(),
               }"
               class="subtitle-2 text-right"
             >
@@ -118,6 +108,22 @@ export default class FetchPresignData extends Vue {
 
   getTypedData() {
     return this.$store.getters.getRequestResponse.typedData
+  }
+
+  getCreatePaymentQueryParams() {
+    return {
+      sourceAddress: this.getTypedData().message.from,
+      paymentIntentId: this.formData.paymentIntentId,
+      destinationAddress: this.getTypedData().message.to,
+      amount: this.getTypedData().totalAmount.amount,
+      currency: this.getTypedData().totalAmount.currency,
+      protocolType: this.getTypedData().totalAmount.primaryType,
+      signature: this.formData.rawSignature,
+      feeQuoteId: this.getTypedData().networkFee?.quoteId,
+      validAfter: this.getTypedData().message.validAfter,
+      metaTxNonce: this.getTypedData().message.nonce,
+      validBefore: this.getTypedData().message.validBefore,
+    }
   }
 
   async makeApiCall() {

--- a/pages/debug/payments/crypto/presign.vue
+++ b/pages/debug/payments/crypto/presign.vue
@@ -42,6 +42,7 @@
               :to="{
                 path: '/debug/payments/crypto/create',
                 query: {
+                  paymentIntentId: formData.paymentIntentId,
                   destinationAddress: getTypedData().message.to,
                   amount: getTypedData().totalAmount.amount,
                   currency: getTypedData().totalAmount.currency,

--- a/pages/debug/payments/crypto/presign.vue
+++ b/pages/debug/payments/crypto/presign.vue
@@ -111,8 +111,13 @@ export default class FetchPresignData extends Vue {
   }
 
   getCreatePaymentQueryParams() {
-    const { paymentIntentId, rawSignature } = this.formData;
-    const {message, totalAmount, networkFee, primaryType: protocolType } = this.getTypedData();
+    const { paymentIntentId, rawSignature } = this.formData
+    const {
+      message,
+      totalAmount,
+      networkFee,
+      primaryType: protocolType,
+    } = this.getTypedData()
     return {
       paymentIntentId,
       amount: totalAmount.amount,
@@ -124,7 +129,7 @@ export default class FetchPresignData extends Vue {
       validAfter: message.validAfter,
       validBefore: message.validBefore,
       metaTxNonce: message.nonce,
-      rawSignature
+      rawSignature,
     }
   }
 

--- a/pages/debug/payments/crypto/presign.vue
+++ b/pages/debug/payments/crypto/presign.vue
@@ -111,18 +111,20 @@ export default class FetchPresignData extends Vue {
   }
 
   getCreatePaymentQueryParams() {
+    const { paymentIntentId, rawSignature } = this.formData;
+    const {message, totalAmount, networkFee, primaryType: protocolType } = this.getTypedData();
     return {
-      sourceAddress: this.getTypedData().message.from,
-      paymentIntentId: this.formData.paymentIntentId,
-      destinationAddress: this.getTypedData().message.to,
-      amount: this.getTypedData().totalAmount.amount,
-      currency: this.getTypedData().totalAmount.currency,
-      protocolType: this.getTypedData().totalAmount.primaryType,
-      signature: this.formData.rawSignature,
-      feeQuoteId: this.getTypedData().networkFee?.quoteId,
-      validAfter: this.getTypedData().message.validAfter,
-      metaTxNonce: this.getTypedData().message.nonce,
-      validBefore: this.getTypedData().message.validBefore,
+      paymentIntentId,
+      amount: totalAmount.amount,
+      currency: totalAmount.currency,
+      sourceAddress: message.from,
+      destinationAddress: message.to,
+      feeQuoteId: networkFee?.quoteId,
+      protocolType,
+      validAfter: message.validAfter,
+      validBefore: message.validBefore,
+      metaTxNonce: message.nonce,
+      rawSignature
     }
   }
 


### PR DESCRIPTION
- Followup to #301 
- `paymentIntentId`, `feeQuoteId` and `sourceAddress` were not passed from GET /presign page to the create payouts page in the last PR. This PR adds it
- Also makes `Fee Quote ID` label in create payments page more clear
![Recording 2023-01-27 at 07 59 32](https://user-images.githubusercontent.com/31556051/215131396-7eb69402-50ba-4073-9284-6ef94e2a6188.gif)
