### PR TITLE
[PAYM-1104] Add form validation for create crypto payment flow

### DIFF
--- a/helpers/validation.ts
+++ b/helpers/validation.ts
@@ -1,0 +1,20 @@
+const isNumber = (v: string) =>
+  v === '' || !isNaN(parseInt(v)) || 'Please enter valid number'
+
+const required = (v: string) => !!v || 'Field is required'
+
+const onlyTwoDecimals = (v: string) => {
+  const [, decimal] = v.split('.')
+  if (!decimal || decimal.length === 2) {
+    return true
+  } else {
+    return 'Decimal amount must have two digits'
+  }
+}
+const uuidRegex =
+  '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
+
+const isUUID = (v: string) =>
+  new RegExp(uuidRegex).test(v) || 'Please enter a valid UUID'
+
+export { isNumber, required, onlyTwoDecimals, isUUID }

--- a/helpers/validation.ts
+++ b/helpers/validation.ts
@@ -3,18 +3,18 @@ const isNumber = (v: string) =>
 
 const required = (v: string) => !!v || 'Field is required'
 
-const onlyTwoDecimals = (v: string) => {
+const validDecimal = (v: string) => {
   const [, decimal] = v.split('.')
-  if (!decimal || decimal.length === 2) {
+  if (decimal === undefined || /^\d{2}$/.test(decimal)) {
     return true
   } else {
-    return 'Decimal amount must have two digits'
+    return 'Decimal must be two digits'
   }
 }
 const uuidRegex =
   '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
 
 const isUUID = (v: string) =>
-  new RegExp(uuidRegex).test(v) || 'Please enter a valid UUID'
+  v === '' || new RegExp(uuidRegex).test(v) || 'Please enter a valid UUID'
 
-export { isNumber, required, onlyTwoDecimals, isUUID }
+export { isNumber, required, validDecimal, isUUID }

--- a/helpers/validation.ts
+++ b/helpers/validation.ts
@@ -1,3 +1,4 @@
+import { validate } from 'uuid'
 const isNumber = (v: string) =>
   v === '' || !isNaN(parseInt(v)) || 'Please enter valid number'
 
@@ -11,10 +12,7 @@ const validDecimal = (v: string) => {
     return 'Decimal must be two digits'
   }
 }
-const uuidRegex =
-  '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
-
 const isUUID = (v: string) =>
-  v === '' || new RegExp(uuidRegex).test(v) || 'Please enter a valid UUID'
+  v === '' || validate(v) || 'Please enter a valid UUID'
 
 export { isNumber, required, validDecimal, isUUID }

--- a/pages/debug/paymentIntents/create.vue
+++ b/pages/debug/paymentIntents/create.vue
@@ -7,7 +7,7 @@
             v-if="transientIntentSelected"
             v-model="formData.amount"
             label="Payment Intent Amount"
-            :rules="[rules.isNumber, rules.validDecimal]"
+            :rules="[rules.isNumber, rules.validDecimal, rules.required]"
           />
 
           <v-select
@@ -113,12 +113,12 @@ interface CurrencyBlockchainPair {
 export default class CreatePaymentIntentClass extends Vue {
   formData = {
     idempotencyKey: '',
-    amount: '0.00',
+    amount: '',
     currency: '',
     settlementCurrency: '',
     blockchain: '',
     expiresOn: '',
-    type: '',
+    type: 'transient',
   }
 
   // validation rules

--- a/pages/debug/paymentIntents/create.vue
+++ b/pages/debug/paymentIntents/create.vue
@@ -2,11 +2,12 @@
   <v-layout>
     <v-row>
       <v-col cols="12" md="4">
-        <v-form>
+        <v-form v-model="isFormValid">
           <v-text-field
             v-if="transientIntentSelected"
             v-model="formData.amount"
             label="Payment Intent Amount"
+            :rules="[rules.isNumber, rules.validDecimal]"
           />
 
           <v-select
@@ -20,6 +21,7 @@
             v-if="currencySelected"
             v-model="formData.blockchain"
             :items="supportedChains"
+            :rules="[rules.required]"
             label="Blockchain"
           />
 
@@ -27,13 +29,8 @@
             v-if="currencySelected"
             v-model="formData.settlementCurrency"
             :items="supportedCurrencies"
+            :rules="[rules.required]"
             label="Settlement Currency"
-          />
-
-          <v-text-field
-            v-if="currencySelected && transientIntentSelected"
-            v-model="formData.expiresOn"
-            label="Expires On"
           />
 
           <header>Optional params:</header>
@@ -44,6 +41,12 @@
             label="Payment Intent Type"
             @change="onIntentTypeChange"
           />
+          <v-text-field
+            v-if="currencySelected && transientIntentSelected"
+            v-model="formData.expiresOn"
+            label="Expires On"
+          />
+
 
           <v-btn
             v-if="currencySelected"
@@ -52,6 +55,7 @@
             color="primary"
             :loading="loading"
             @click.prevent="makeApiCall"
+            :disabled="!isFormValid"
           >
             Make api call
           </v-btn>
@@ -83,6 +87,7 @@ import {
   CreateContinuousPaymentIntentPayload,
   CreateTransientPaymentIntentPayload,
 } from '@/lib/paymentIntentsApi'
+import { isNumber, required, validDecimal} from '@/helpers/validation'
 
 interface CurrencyBlockchainPair {
   currency: string
@@ -102,6 +107,9 @@ interface CurrencyBlockchainPair {
       isMarketplace: 'isMarketplace',
     }),
   },
+  data: () => ({
+    isFormValid: false,
+  }),
 })
 export default class CreatePaymentIntentClass extends Vue {
   formData = {
@@ -114,7 +122,13 @@ export default class CreatePaymentIntentClass extends Vue {
     type: '',
   }
 
-  required = [(v: string) => !!v || 'Field is required']
+  // validation rules
+  rules = {
+    isNumber,
+    required,
+    validDecimal,
+  }
+
   error = {}
   loading = false
   showError = false

--- a/pages/debug/paymentIntents/create.vue
+++ b/pages/debug/paymentIntents/create.vue
@@ -47,15 +47,14 @@
             label="Expires On"
           />
 
-
           <v-btn
             v-if="currencySelected"
             depressed
             class="mb-7"
             color="primary"
             :loading="loading"
-            @click.prevent="makeApiCall"
             :disabled="!isFormValid"
+            @click.prevent="makeApiCall"
           >
             Make api call
           </v-btn>
@@ -87,7 +86,7 @@ import {
   CreateContinuousPaymentIntentPayload,
   CreateTransientPaymentIntentPayload,
 } from '@/lib/paymentIntentsApi'
-import { isNumber, required, validDecimal} from '@/helpers/validation'
+import { isNumber, required, validDecimal } from '@/helpers/validation'
 
 interface CurrencyBlockchainPair {
   currency: string

--- a/pages/debug/payments/crypto/create.vue
+++ b/pages/debug/payments/crypto/create.vue
@@ -2,14 +2,18 @@
   <v-layout>
     <v-row>
       <v-col cols="12" md="4">
-        <v-form>
+        <v-form v-model="isFormValid">
           <v-text-field
             v-model="formData.paymentIntentId"
-            hint="Payment Intent Id"
+            :rules="[rules.required, rules.isUUID]"
             label="Payment Intent Id"
           />
 
-          <v-text-field v-model="formData.amount" label="Amount" />
+          <v-text-field
+            v-model="formData.amount"
+            label="Amount"
+            :rules="[rules.required, rules.isNumber, rules.validDecimal]"
+          />
           <v-select
             v-model="formData.currency"
             :items="currency"
@@ -18,16 +22,19 @@
 
           <v-text-field
             v-model="formData.sourceAddress"
+            :rules="[rules.required]"
             label="Source Address"
           />
           <v-select
             v-model="formData.sourceType"
             :items="sourceType"
+            :rules="[rules.required]"
             label="Source Type"
           />
 
           <v-text-field
             v-model="formData.destinationAddress"
+            :rules="[rules.required]"
             label="Destination Address"
           />
           <v-select
@@ -38,7 +45,8 @@
 
           <v-text-field
             v-model="formData.feeQuoteId"
-            label="Fee Quote UUID (Required if network fees paid by end user)"
+            label="Fee Quote ID (Required if network fees paid by end user)"
+            :rules="[rules.isUUID]"
           />
 
           <v-select
@@ -49,26 +57,26 @@
 
           <v-text-field
             v-model="formData.validAfter"
-            hint="Signature ValidAfter"
             label="Signature ValidAfter"
+            :rules="[rules.required]"
           />
 
           <v-text-field
             v-model="formData.validBefore"
-            hint="Signature validBefore"
             label="Signature validBefore"
+            :rules="[rules.required]"
           />
 
           <v-text-field
             v-model="formData.metaTxNonce"
-            hint="Meta transaction nonce"
             label="Meta transaction nonce"
+            :rules="[rules.required]"
           />
 
           <v-text-field
             v-model="formData.rawSignature"
-            hint="ECDSA rawSignature"
             label="ECDSA rawSignature"
+            :rules="[rules.required]"
           />
 
           <v-btn
@@ -76,6 +84,7 @@
             class="mb-7"
             color="primary"
             :loading="loading"
+            :disabled="!isFormValid"
             @click.prevent="makeApiCall()"
           >
             Make api call
@@ -105,6 +114,7 @@ import { v4 as uuidv4 } from 'uuid'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
 import { CreateCryptoPaymentPayload } from '~/lib/cryptoPaymentsApi'
+import { isNumber, required, validDecimal, isUUID } from '@/helpers/validation'
 
 @Component({
   components: {
@@ -119,6 +129,9 @@ import { CreateCryptoPaymentPayload } from '~/lib/cryptoPaymentsApi'
       isMarketplace: 'isMarketplace',
     }),
   },
+  data: () => ({
+    isFormValid: false,
+  }),
 })
 export default class CreatePaymentClass extends Vue {
   formData = {
@@ -138,11 +151,18 @@ export default class CreatePaymentClass extends Vue {
     rawSignature: (this.$route.query.rawSignature as string) || '',
   }
 
+  // validation rules
+  rules = {
+    isNumber,
+    required,
+    validDecimal,
+    isUUID,
+  }
+
   sourceType = ['blockchain']
   currency = ['USD']
   destinationChain = ['ETH']
   protocolType = ['TransferWithAuthorization']
-  required = [(v: string) => !!v || 'Field is required']
   error = {}
   loading = false
   showError = false

--- a/pages/debug/payments/crypto/presign.vue
+++ b/pages/debug/payments/crypto/presign.vue
@@ -2,23 +2,31 @@
   <v-layout>
     <v-row>
       <v-col cols="12" md="4">
-        <v-form>
+        <v-form v-model="isFormValid"
+          >
           <v-text-field
             v-model="formData.paymentIntentId"
+            :rules="[rules.required, rules.isUUID]"
             label="Payment Intent Id"
           />
           <v-text-field
             v-model="formData.endUserAddress"
+            :rules="[rules.required]"
             label="End User Address"
           />
           <header>Optional params:</header>
-          <v-text-field v-model="formData.amount" label="Amount" />
+          <v-text-field
+            v-model="formData.amount"
+            label="Amount"
+            :rules="[rules.isNumber, rules.onlyTwoDecimals]"
+          />
           <v-text-field v-model="formData.currency" label="Currency" />
           <v-btn
             depressed
             class="mb-7"
             color="primary"
             @click.prevent="makeApiCall()"
+:disabled="!isFormValid"
           >
             Make api call
           </v-btn>
@@ -72,6 +80,7 @@ import { mapGetters } from 'vuex'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
 import { sendPresignedDataToMetaMask } from '~/lib/walletConnect'
+import { isNumber, required, onlyTwoDecimals, isUUID } from '@/helpers/validation'
 
 @Component({
   components: {
@@ -85,6 +94,9 @@ import { sendPresignedDataToMetaMask } from '~/lib/walletConnect'
       requestUrl: 'getRequestUrl',
     }),
   },
+data: () => ({
+  isFormValid: false,
+})
 })
 export default class FetchPresignData extends Vue {
   error = {}
@@ -98,6 +110,14 @@ export default class FetchPresignData extends Vue {
     amount: '',
     currency: '',
     rawSignature: '',
+  }
+
+  // validation rules
+  rules = {
+    isNumber,
+    required,
+    onlyTwoDecimals,   
+    isUUID,
   }
 
   // methods

--- a/pages/debug/payments/crypto/presign.vue
+++ b/pages/debug/payments/crypto/presign.vue
@@ -2,8 +2,7 @@
   <v-layout>
     <v-row>
       <v-col cols="12" md="4">
-        <v-form v-model="isFormValid"
-          >
+        <v-form v-model="isFormValid">
           <v-text-field
             v-model="formData.paymentIntentId"
             :rules="[rules.required, rules.isUUID]"
@@ -18,15 +17,15 @@
           <v-text-field
             v-model="formData.amount"
             label="Amount"
-            :rules="[rules.isNumber, rules.onlyTwoDecimals]"
+            :rules="[rules.isNumber, rules.validDecimal]"
           />
           <v-text-field v-model="formData.currency" label="Currency" />
           <v-btn
             depressed
             class="mb-7"
             color="primary"
+            :disabled="!isFormValid"
             @click.prevent="makeApiCall()"
-:disabled="!isFormValid"
           >
             Make api call
           </v-btn>
@@ -80,7 +79,7 @@ import { mapGetters } from 'vuex'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
 import { sendPresignedDataToMetaMask } from '~/lib/walletConnect'
-import { isNumber, required, onlyTwoDecimals, isUUID } from '@/helpers/validation'
+import { isNumber, required, validDecimal, isUUID } from '@/helpers/validation'
 
 @Component({
   components: {
@@ -94,9 +93,9 @@ import { isNumber, required, onlyTwoDecimals, isUUID } from '@/helpers/validatio
       requestUrl: 'getRequestUrl',
     }),
   },
-data: () => ({
-  isFormValid: false,
-})
+  data: () => ({
+    isFormValid: false,
+  }),
 })
 export default class FetchPresignData extends Vue {
   error = {}
@@ -116,7 +115,7 @@ export default class FetchPresignData extends Vue {
   rules = {
     isNumber,
     required,
-    onlyTwoDecimals,   
+    validDecimal,
     isUUID,
   }
 


### PR DESCRIPTION
- This PR adds form validation to the pages involved in the create crypto payment flow so we don't send invalid inputs.
- Create payment intents page:
![Recording 2023-01-30 at 17 36 41](https://user-images.githubusercontent.com/31556051/215637361-5709dc19-0c15-4e3f-9c4f-5f68a215d989.gif)

- Presign page:
![Recording 2023-01-30 at 17 39 05](https://user-images.githubusercontent.com/31556051/215637445-d96527b4-825e-4759-b30a-ff7140cfe840.gif)

- Create crypto payments page
![Recording 2023-01-30 at 17 41 53](https://user-images.githubusercontent.com/31556051/215637894-c9662dd4-87f8-488c-b0f0-67056f956530.gif)
