### PR TITLE
[PPAYM-1105] Add optional merchantWalletId field to payment intents

### DIFF
--- a/lib/paymentIntentsApi.ts
+++ b/lib/paymentIntentsApi.ts
@@ -16,6 +16,7 @@ export interface CreateTransientPaymentIntentPayload {
   }
   settlementCurrency: string
   paymentMethods: Array<PaymentMethod>
+  merchantWalletId: string
   expiresOn: string
 }
 
@@ -24,6 +25,7 @@ export interface CreateContinuousPaymentIntentPayload {
   currency: string
   settlementCurrency: string
   paymentMethods: Array<PaymentMethod>
+  merchantWalletId: string
   type: string
 }
 

--- a/pages/debug/paymentIntents/create.vue
+++ b/pages/debug/paymentIntents/create.vue
@@ -47,6 +47,11 @@
             label="Expires On"
           />
 
+          <v-text-field
+            v-model="formData.merchantWalletId"
+            label="Merchant Wallet Id"
+          />
+
           <v-btn
             v-if="currencySelected"
             depressed
@@ -115,6 +120,7 @@ export default class CreatePaymentIntentClass extends Vue {
     idempotencyKey: '',
     amount: '',
     currency: '',
+    merchantWalletId: '',
     settlementCurrency: '',
     blockchain: '',
     expiresOn: '',
@@ -188,6 +194,7 @@ export default class CreatePaymentIntentClass extends Vue {
         amount: amountDetail,
         settlementCurrency: this.formData.settlementCurrency,
         paymentMethods: [blockchainPaymentMethod],
+        merchantWalletId: this.formData.merchantWalletId,
         expiresOn: this.formData.expiresOn,
       }
       try {
@@ -204,6 +211,7 @@ export default class CreatePaymentIntentClass extends Vue {
         currency: this.formData.currency,
         settlementCurrency: this.formData.settlementCurrency,
         paymentMethods: [blockchainPaymentMethod],
+        merchantWalletId: this.formData.merchantWalletId,
         type: this.formData.type,
       }
       try {


### PR DESCRIPTION
Add support for subwallet id in payment intents 

![image](https://user-images.githubusercontent.com/108296706/218484282-8bf6e674-a3f3-4809-a8b0-2af9adc6672c.png)
