### PR TITLE
[PAYM-1105] Only Include merchantWalletId in request if non-empty

### DIFF
--- a/lib/paymentIntentsApi.ts
+++ b/lib/paymentIntentsApi.ts
@@ -16,7 +16,7 @@ export interface CreateTransientPaymentIntentPayload {
   }
   settlementCurrency: string
   paymentMethods: Array<PaymentMethod>
-  merchantWalletId: string
+  merchantWalletId?: string
   expiresOn: string
 }
 
@@ -25,7 +25,7 @@ export interface CreateContinuousPaymentIntentPayload {
   currency: string
   settlementCurrency: string
   paymentMethods: Array<PaymentMethod>
-  merchantWalletId: string
+  merchantWalletId?: string
   type: string
 }
 

--- a/pages/debug/paymentIntents/create.vue
+++ b/pages/debug/paymentIntents/create.vue
@@ -194,9 +194,13 @@ export default class CreatePaymentIntentClass extends Vue {
         amount: amountDetail,
         settlementCurrency: this.formData.settlementCurrency,
         paymentMethods: [blockchainPaymentMethod],
-        merchantWalletId: this.formData.merchantWalletId,
         expiresOn: this.formData.expiresOn,
       }
+
+      if (this.formData.merchantWalletId !== '') {
+        payload.merchantWalletId = this.formData.merchantWalletId
+      }
+
       try {
         await this.$paymentIntentsApi.createTransientPaymentIntent(payload)
       } catch (error) {
@@ -211,9 +215,13 @@ export default class CreatePaymentIntentClass extends Vue {
         currency: this.formData.currency,
         settlementCurrency: this.formData.settlementCurrency,
         paymentMethods: [blockchainPaymentMethod],
-        merchantWalletId: this.formData.merchantWalletId,
         type: this.formData.type,
       }
+
+      if (this.formData.merchantWalletId !== '') {
+        payload.merchantWalletId = this.formData.merchantWalletId
+      }
+
       try {
         await this.$paymentIntentsApi.createContinuousPaymentIntent(payload)
       } catch (error) {


### PR DESCRIPTION
We should only include merchantWalletId param in the request if the field is non-empty string.