### PR TITLE
[PAYM-1138] Autofill quote id from presign page to create payment page when network fee payer = endUser

### DIFF
--- a/pages/debug/payments/crypto/presign.vue
+++ b/pages/debug/payments/crypto/presign.vue
@@ -134,7 +134,8 @@ export default class FetchPresignData extends Vue {
     const {
       message,
       totalAmount,
-      networkFee,
+      networkFeeQuote,
+      feeChargeModel,
       primaryType: protocolType,
     } = this.getTypedData()
     return {
@@ -143,7 +144,7 @@ export default class FetchPresignData extends Vue {
       currency: totalAmount.currency,
       sourceAddress: message.from,
       destinationAddress: message.to,
-      feeQuoteId: networkFee?.quoteId,
+      feeQuoteId: feeChargeModel === 'endUser' ? networkFeeQuote?.quoteId : '',
       protocolType,
       validAfter: message.validAfter,
       validBefore: message.validBefore,


### PR DESCRIPTION
- Noticed a small annoyance when trying to test GET /presign that the quote ID is not autofilled to the create payments page when `networkFeePayer` is set to `endUser`
- This PR adds this feature
![Recording 2023-02-17 at 17 50 00](https://user-images.githubusercontent.com/31556051/219825429-3fec6e1d-a29d-4f59-8edf-ec7284ab5a13.gif)
