### PR TITLE
[Untracked]Support EUR in mock wire

### DIFF
--- a/pages/debug/payments/mocks/wire.vue
+++ b/pages/debug/payments/mocks/wire.vue
@@ -8,6 +8,11 @@
             v-model="formData.accountNumber"
             label="Account Number"
           />
+          <v-select
+            v-model="formData.currency"
+            :items="currencyTypes"
+            label="Currency"
+          />
           <v-text-field v-model="formData.amount" label="Amount" />
           <v-btn
             v-if="isSandbox"
@@ -62,7 +67,10 @@ export default class CreateMockIncomingWireClass extends Vue {
     trackingRef: '',
     accountNumber: '',
     amount: '0.00',
+    currency: 'USD', // Default to USD
   }
+
+  currencyTypes = ['USD', 'EUR']
 
   isSandbox: Boolean = !getLive()
   required = [(v: string) => !!v || 'Field is required']
@@ -78,7 +86,7 @@ export default class CreateMockIncomingWireClass extends Vue {
     this.loading = true
     const amountDetail = {
       amount: this.formData.amount,
-      currency: 'USD',
+      currency: this.formData.currency,
     }
     const payload: CreateMockPushPaymentPayload = {
       trackingRef: this.formData.trackingRef,


### PR DESCRIPTION
We need to support EUR in mock wires
<img width="1506" alt="image" src="https://github.com/circlefin/payments-sample-app/assets/113938057/d5ebe981-b230-4271-a3d6-4ca72b27cb20">
