### PR TITLE
[BANK-490] Add UI for RTP APIs

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -347,6 +347,22 @@ export default class DefaultLayoutsClass extends Vue {
       to: '/debug/businessAccount/xpayAccounts/instructions',
     },
     {
+      title: 'POST /businessAccount/banks/rtp',
+      to: '/debug/businessAccount/rtpAccounts/create',
+    },
+    {
+      title: 'GET /businessAccount/banks/rtp',
+      to: '/debug/businessAccount/rtpAccounts/fetch',
+    },
+    {
+      title: 'GET /businessAccount/banks/rtp/{id}',
+      to: '/debug/businessAccount/rtpAccounts/details',
+    },
+    {
+      title: 'GET /businessAccount/banks/rtp/{id}/instructions',
+      to: '/debug/businessAccount/rtpAccounts/instructions',
+    },
+    {
       title: 'POST /businessAccount/transfers',
       to: '/debug/businessAccount/transfers/create',
     },

--- a/lib/businessAccount/rtpAccountsApi.ts
+++ b/lib/businessAccount/rtpAccountsApi.ts
@@ -68,7 +68,9 @@ function createRTPAccount(payload: CreateRTPAccountPayload) {
   payload.billingDetails.line1 = nullIfEmpty(payload.billingDetails.line1)
   payload.billingDetails.line2 = nullIfEmpty(payload.billingDetails.line2)
   payload.billingDetails.district = nullIfEmpty(payload.billingDetails.district)
-  payload.billingDetails.postalCode = nullIfEmpty(payload.billingDetails.postalCode)
+  payload.billingDetails.postalCode = nullIfEmpty(
+    payload.billingDetails.postalCode
+  )
   return instance.post(url, payload)
 }
 

--- a/lib/businessAccount/rtpAccountsApi.ts
+++ b/lib/businessAccount/rtpAccountsApi.ts
@@ -1,0 +1,109 @@
+import get from 'lodash/get'
+import axios from 'axios'
+
+import { getAPIHostname } from '../apiTarget'
+
+export interface CreateRTPAccountPayload {
+  idempotencyKey: string
+  accountNumber?: string
+  routingNumber?: string
+  billingDetails: {
+    name?: string
+    city?: string
+    country?: string
+    line1?: string
+    line2?: string
+    district?: string
+    postalCode?: string
+  }
+}
+
+const instance = axios.create({
+  baseURL: getAPIHostname(),
+})
+
+/**
+ * Global error handler:
+ * Intercepts all axios reponses and maps
+ * to errorHandler object
+ */
+instance.interceptors.response.use(
+  function (response) {
+    if (get(response, 'data.data')) {
+      return response.data.data
+    }
+    return response
+  },
+  function (error) {
+    let response = get(error, 'response')
+    if (!response) {
+      response = error.toJSON()
+    }
+    return Promise.reject(response)
+  }
+)
+
+const nullIfEmpty = (prop: string | undefined) => {
+  if (prop === '') {
+    return undefined
+  }
+  return prop
+}
+
+/** Returns the axios instance */
+function getInstance() {
+  return instance
+}
+
+/**
+ * Create RTP bank account
+ * @param {*} payload (contains form data)
+ */
+function createRTPAccount(payload: CreateRTPAccountPayload) {
+  const url = '/v1/businessAccount/banks/rtp'
+  payload.accountNumber = nullIfEmpty(payload.accountNumber)
+  payload.routingNumber = nullIfEmpty(payload.routingNumber)
+  payload.billingDetails.name = nullIfEmpty(payload.billingDetails.name)
+  payload.billingDetails.city = nullIfEmpty(payload.billingDetails.city)
+  payload.billingDetails.line1 = nullIfEmpty(payload.billingDetails.line1)
+  payload.billingDetails.line2 = nullIfEmpty(payload.billingDetails.line2)
+  payload.billingDetails.district = nullIfEmpty(payload.billingDetails.district)
+  payload.billingDetails.postalCode = nullIfEmpty(payload.billingDetails.postalCode)
+  return instance.post(url, payload)
+}
+
+/**
+ * Get RTP bank accounts
+ */
+function getRTPAccounts() {
+  const url = '/v1/businessAccount/banks/rtp'
+  return instance.get(url)
+}
+
+/**
+ * Get RTP bank account by id
+ * @param {String} bankId
+ */
+function getRTPAccountById(bankId: string) {
+  const url = `/v1/businessAccount/banks/rtp/${bankId}`
+
+  return instance.get(url)
+}
+
+/**
+ * Get RTP bank account instructions
+ * @param {String} bankId
+ */
+function getRTPAccountInstructions(bankId: string) {
+  const url = `/v1/businessAccount/banks/rtp/${bankId}/instructions`
+
+  return instance.get(url)
+}
+
+export default {
+  getInstance,
+  createRTPAccount,
+  getRTPAccounts,
+  getRTPAccountById,
+  getRTPAccountInstructions,
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -59,6 +59,7 @@ export default {
     '~/plugins/businessAccount/bankAccountsApi',
     '~/plugins/businessAccount/cbitAccountsApi',
     '~/plugins/businessAccount/xpayAccountsApi',
+    '~/plugins/businessAccount/rtpAccountsApi',
     '~/plugins/businessAccount/depositsApi',
     '~/plugins/businessAccount/payoutsApi',
     '~/plugins/businessAccount/transfersApi',

--- a/pages/debug/businessAccount/payouts/create.vue
+++ b/pages/debug/businessAccount/payouts/create.vue
@@ -81,6 +81,7 @@ export default class CreatePayoutClass extends Vue {
   }
 
   required = [(v: string) => !!v || 'Field is required']
+  // only include xpay and rtp in local dev and smokebox
   destinationType =
     getAPIHostname()!.includes('smokebox') ||
     getAPIHostname()!.includes(':3011')

--- a/pages/debug/businessAccount/payouts/create.vue
+++ b/pages/debug/businessAccount/payouts/create.vue
@@ -56,8 +56,6 @@ import { v4 as uuidv4 } from 'uuid'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
 import { CreatePayoutPayload } from '@/lib/businessAccount/payoutsApi'
-import { getAPIHostname } from '@/lib/apiTarget'
-
 @Component({
   components: {
     RequestInfo,

--- a/pages/debug/businessAccount/payouts/create.vue
+++ b/pages/debug/businessAccount/payouts/create.vue
@@ -56,6 +56,8 @@ import { v4 as uuidv4 } from 'uuid'
 import RequestInfo from '@/components/RequestInfo.vue'
 import ErrorSheet from '@/components/ErrorSheet.vue'
 import { CreatePayoutPayload } from '@/lib/businessAccount/payoutsApi'
+import { getAPIHostname } from '@/lib/apiTarget'
+
 @Component({
   components: {
     RequestInfo,
@@ -79,7 +81,12 @@ export default class CreatePayoutClass extends Vue {
   }
 
   required = [(v: string) => !!v || 'Field is required']
-  destinationType = ['wire', 'cbit', 'xpay', 'rtp']
+  destinationType =
+    getAPIHostname()!.includes('smokebox') ||
+    getAPIHostname()!.includes(':3011')
+      ? ['wire', 'cbit', 'xpay', 'rtp']
+      : ['wire', 'cbit']
+
   wireCurrencyTypes = ['USD', 'EUR']
   cbitCurrencyTypes = ['USD']
   currencyTypes = new Map([

--- a/pages/debug/businessAccount/payouts/create.vue
+++ b/pages/debug/businessAccount/payouts/create.vue
@@ -79,12 +79,14 @@ export default class CreatePayoutClass extends Vue {
   }
 
   required = [(v: string) => !!v || 'Field is required']
-  destinationType = ['wire', 'cbit']
+  destinationType = ['wire', 'cbit', 'xpay', 'rtp']
   wireCurrencyTypes = ['USD', 'EUR']
   cbitCurrencyTypes = ['USD']
   currencyTypes = new Map([
     ['wire', this.wireCurrencyTypes],
     ['cbit', this.cbitCurrencyTypes],
+    ['xpay', ['USD']],
+    ['rtp', ['USD']],
   ])
 
   error = {}

--- a/pages/debug/businessAccount/payouts/create.vue
+++ b/pages/debug/businessAccount/payouts/create.vue
@@ -82,11 +82,7 @@ export default class CreatePayoutClass extends Vue {
 
   required = [(v: string) => !!v || 'Field is required']
   // only include xpay and rtp in local dev and smokebox
-  destinationType =
-    getAPIHostname()!.includes('smokebox') ||
-    getAPIHostname()!.includes(':3011')
-      ? ['wire', 'cbit', 'xpay', 'rtp']
-      : ['wire', 'cbit']
+  destinationType = ['wire', 'cbit', 'xpay', 'rtp']
 
   wireCurrencyTypes = ['USD', 'EUR']
   cbitCurrencyTypes = ['USD']

--- a/pages/debug/businessAccount/rtpAccounts/create.vue
+++ b/pages/debug/businessAccount/rtpAccounts/create.vue
@@ -1,0 +1,177 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="formData.accountNumber"
+            label="Account Number"
+          />
+
+          <v-text-field
+            v-model="formData.routingNumber"
+            label="Routing Number"
+            hint="RTN/BIC/Swift code of the bank associated with the account. Required for US accounts"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.name"
+            label="Billing Name"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.line1"
+            label="Billing Address Line 1"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.line2"
+            label="Billing Address Line 2"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.postalCode"
+            label="Billing Postalcode"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.city"
+            label="Billing City"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.district"
+            label="Billing District"
+            hint="State / County / Province / Region portion of the address. US and Canada use the two-letter code for the subdivision"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.country"
+            label="Billing Country Code"
+          />
+
+          <v-btn
+            depressed
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import { v4 as uuidv4 } from 'uuid'
+import { getLive } from '@/lib/apiTarget'
+import { CreateRTPAccountPayload } from '@/lib/businessAccount/rtpAccountsApi'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+    }),
+  },
+})
+export default class CreateRTPClass extends Vue {
+  // data
+  formData = {
+    beneficiaryName: '',
+    accountNumber: '',
+    routingNumber: '',
+    iban: '',
+    billingDetails: {
+      name: '',
+      city: '',
+      country: '',
+      line1: '',
+      line2: '',
+      district: '',
+      postalCode: '',
+    },
+    bankAddress: {
+      bankName: '',
+      city: '',
+      country: '',
+      line1: '',
+      line2: '',
+      district: '',
+      postalCode: '',
+    },
+  }
+
+  rules = {
+    isNumber: (v: string) =>
+      v === '' || !isNaN(parseInt(v)) || 'Please enter valid number',
+    required: (v: string) => !!v || 'Field is required',
+  }
+
+  error = {}
+  loading = false
+  showError = false
+  expiryLabels = {
+    month: 'Expiry Month',
+    year: 'Expiry Year',
+  }
+
+  isSandbox: Boolean = !getLive()
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  async makeApiCall() {
+    this.loading = true
+    const { accountNumber, routingNumber, ...data } = this.formData
+    const { billingDetails } = data
+
+    const payload: CreateRTPAccountPayload = {
+      idempotencyKey: uuidv4(),
+      accountNumber,
+      routingNumber,
+      billingDetails: {
+        name: billingDetails.name,
+        line1: billingDetails.line1,
+        line2: billingDetails.line2,
+        city: billingDetails.city,
+        district: billingDetails.district,
+        country: billingDetails.country,
+        postalCode: billingDetails.postalCode,
+      },
+    }
+
+    try {
+      await this.$rtpAccountsApi.createRTPAccount(payload)
+    } catch (error: any) {
+      this.error = error
+      this.showError = true
+    } finally {
+      this.loading = false
+    }
+  }
+}
+</script>

--- a/pages/debug/businessAccount/rtpAccounts/details.vue
+++ b/pages/debug/businessAccount/rtpAccounts/details.vue
@@ -1,0 +1,90 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form ref="form" lazy-validation>
+          <v-text-field
+            v-model="formData.accountId"
+            label="Account Id"
+            :rules="requiredRules"
+            required
+          />
+          <v-btn
+            depressed
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+    }),
+  },
+})
+export default class FetchRTPBusinessAccountDetailsClass extends Vue {
+  // data
+  formData = {
+    accountId: '',
+  }
+
+  requiredRules = [(v: string) => !!v || 'Field is required']
+  error = {}
+  loading = false
+  showError = false
+  // methods
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  async makeApiCall() {
+    const form = this.$refs.form as any
+    if (form.validate()) {
+      this.loading = true
+      try {
+        await this.$rtpAccountsApi.getRTPAccountById(
+          this.formData.accountId
+        )
+      } catch (error: any) {
+        this.error = error
+        this.showError = true
+      } finally {
+        this.loading = false
+      }
+    }
+  }
+}
+</script>

--- a/pages/debug/businessAccount/rtpAccounts/details.vue
+++ b/pages/debug/businessAccount/rtpAccounts/details.vue
@@ -75,9 +75,7 @@ export default class FetchRTPBusinessAccountDetailsClass extends Vue {
     if (form.validate()) {
       this.loading = true
       try {
-        await this.$rtpAccountsApi.getRTPAccountById(
-          this.formData.accountId
-        )
+        await this.$rtpAccountsApi.getRTPAccountById(this.formData.accountId)
       } catch (error: any) {
         this.error = error
         this.showError = true

--- a/pages/debug/businessAccount/rtpAccounts/fetch.vue
+++ b/pages/debug/businessAccount/rtpAccounts/fetch.vue
@@ -1,0 +1,72 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-btn
+            depressed
+            class="mb-7"
+            color="primary"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+    }),
+  },
+})
+export default class FetchRTPBusinessAccountsClass extends Vue {
+  error = {}
+  loading = false
+  showError = false
+  // methods
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  async makeApiCall() {
+    this.loading = true
+    try {
+      await this.$rtpAccountsApi.getRTPAccounts()
+    } catch (error: any) {
+      this.error = error
+      this.showError = true
+    } finally {
+      this.loading = false
+    }
+  }
+}
+</script>

--- a/pages/debug/businessAccount/rtpAccounts/instructions.vue
+++ b/pages/debug/businessAccount/rtpAccounts/instructions.vue
@@ -1,0 +1,92 @@
+<template>
+  <v-layout>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form ref="form" lazy-validation>
+          <v-text-field
+            v-model="formData.accountId"
+            label="Account Id"
+            :rules="requiredRules"
+            required
+          />
+          <v-btn
+            depressed
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @onChange="onErrorSheetClosed"
+    />
+  </v-layout>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator'
+import { mapGetters } from 'vuex'
+import RequestInfo from '@/components/RequestInfo.vue'
+import ErrorSheet from '@/components/ErrorSheet.vue'
+
+@Component({
+  components: {
+    RequestInfo,
+    ErrorSheet,
+  },
+  computed: {
+    ...mapGetters({
+      payload: 'getRequestPayload',
+      response: 'getRequestResponse',
+      requestUrl: 'getRequestUrl',
+    }),
+  },
+})
+export default class FetchRTPBusinessAccountInstructionsClass extends Vue {
+  // data
+  formData = {
+    accountId: '',
+  }
+
+  requiredRules = [(v: string) => !!v || 'Field is required']
+  error = {}
+  loading = false
+  showError = false
+
+  // methods
+  onErrorSheetClosed() {
+    this.error = {}
+    this.showError = false
+  }
+
+  async makeApiCall() {
+    const form = this.$refs.form as any
+    if (form.validate()) {
+      this.loading = true
+      try {
+        await this.$rtpAccountsApi.getRTPAccountInstructions(
+          this.formData.accountId
+        )
+      } catch (error: any) {
+        this.error = error
+        this.showError = true
+      } finally {
+        this.loading = false
+      }
+    }
+  }
+}
+</script>

--- a/plugins/businessAccount/rtpAccountsApi.ts
+++ b/plugins/businessAccount/rtpAccountsApi.ts
@@ -1,0 +1,47 @@
+import rtpAccountsApi, {
+  CreateRTPAccountPayload,
+} from '@/lib/businessAccount/rtpAccountsApi'
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $rtpAccountsApi: {
+      getInstance: any
+      createRTPAccount: (payload: CreateRTPAccountPayload) => any
+      getRTPAccounts: any
+      getRTPAccountById: any
+      getRTPAccountInstructions: any
+    }
+  }
+}
+
+export default ({ store }: any, inject: any) => {
+  const instance = rtpAccountsApi.getInstance()
+
+  instance.interceptors.request.use(
+    function (config) {
+      store.commit('CLEAR_REQUEST_DATA')
+      store.commit('SET_REQUEST_URL', `${config.baseURL}${config.url}`)
+      store.commit('SET_REQUEST_PAYLOAD', config.data)
+
+      if (store.state.bearerToken) {
+        config.headers = { Authorization: `Bearer ${store.state.bearerToken}` }
+      }
+      return config
+    },
+    function (error) {
+      return Promise.reject(error)
+    }
+  )
+
+  instance.interceptors.response.use(
+    function (response) {
+      store.commit('SET_RESPONSE', response)
+      return response
+    },
+    function (error) {
+      return Promise.reject(error)
+    }
+  )
+
+  inject('rtpAccountsApi', rtpAccountsApi)
+}


### PR DESCRIPTION
Add xpay and rtp to fiat account type

<img width="1679" alt="image" src="https://github.com/circlefin/payments-sample-app/assets/115195453/65ce39e5-5aed-47fd-b5ec-403530dcaa26">

Add pages for RTP fiat account APIs

<img width="1679" alt="image" src="https://github.com/circlefin/payments-sample-app/assets/115195453/d758708a-1314-4e08-8fe8-11def318a03a">

<img width="1679" alt="image" src="https://github.com/circlefin/payments-sample-app/assets/115195453/9197c415-3de8-4211-98a1-08beca9bd800">

<img width="1679" alt="image" src="https://github.com/circlefin/payments-sample-app/assets/115195453/901f9b79-c397-47d2-8d66-c08d27024a20">

<img width="1679" alt="image" src="https://github.com/circlefin/payments-sample-app/assets/115195453/e4d75cf6-be75-4006-9f1f-b39fa07352d7">


