### PR TITLE
Add support for XPay in payouts api

### DIFF
--- a/pages/debug/businessAccount/payouts/create.vue
+++ b/pages/debug/businessAccount/payouts/create.vue
@@ -79,12 +79,14 @@ export default class CreatePayoutClass extends Vue {
   }
 
   required = [(v: string) => !!v || 'Field is required']
-  destinationType = ['wire', 'cbit']
+  destinationType = ['wire', 'cbit', 'xpay']
   wireCurrencyTypes = ['USD', 'EUR']
   cbitCurrencyTypes = ['USD']
+  xpayCurrencyTypes = ['USD']
   currencyTypes = new Map([
     ['wire', this.wireCurrencyTypes],
     ['cbit', this.cbitCurrencyTypes],
+    ['xpay', this.xpayCurrencyTypes],
   ])
 
   error = {}


### PR DESCRIPTION
Previously we added support for APIs related to managing xpay accounts.

In this PR we add xpay as an option in the core payouts API. 
<img width="1849" alt="Screenshot 2023-06-23 at 11 46 16" src="https://github.com/circlefin/payments-sample-app/assets/105304719/5372d947-e4f2-4de9-b110-4abf6e6f97ca">
