### PR TITLE
Add FFC and intermediary bank into to wire fiat account linking

### DIFF
--- a/lib/businessAccount/bankAccountsApi.ts
+++ b/lib/businessAccount/bankAccountsApi.ts
@@ -9,6 +9,7 @@ export interface CreateWireAccountPayload {
   accountNumber?: string
   routingNumber?: string
   iban?: string
+  ffcMemo?: string
   billingDetails: {
     name: string
     city: string
@@ -26,6 +27,11 @@ export interface CreateWireAccountPayload {
     line2?: string
     district?: string
     postalCode?: string
+  }
+  intermediaryBank?: {
+    identifier?: string
+    type?: string
+    countryCode?: string
   }
 }
 

--- a/lib/businessAccount/bankAccountsTestData.ts
+++ b/lib/businessAccount/bankAccountsTestData.ts
@@ -6,6 +6,7 @@ export const exampleBankAccounts = [
       accountNumber: '11111111111',
       routingNumber: '121000248',
       iban: '',
+      ffcMemo: '',
       billingDetails: {
         name: 'Satoshi Nakamoto',
         city: 'Boston',
@@ -24,6 +25,11 @@ export const exampleBankAccounts = [
         district: '',
         postalCode: '',
       },
+      intermediaryBank: {
+        identifier: '',
+        type: '',
+        countryCode: '',
+      },
     },
   },
   {
@@ -33,6 +39,7 @@ export const exampleBankAccounts = [
       accountNumber: '',
       routingNumber: '',
       iban: 'DE31100400480532013000',
+      ffcMemo: '',
       billingDetails: {
         name: 'Satoshi Nakamoto',
         city: 'Boston',
@@ -51,6 +58,11 @@ export const exampleBankAccounts = [
         district: '',
         postalCode: '',
       },
+      intermediaryBank: {
+        identifier: '',
+        type: '',
+        countryCode: '',
+      },
     },
   },
   {
@@ -60,6 +72,7 @@ export const exampleBankAccounts = [
       accountNumber: '002010077777777771',
       routingNumber: 'BDEMMXMF',
       iban: '',
+      ffcMemo: '',
       billingDetails: {
         name: 'Satoshi Nakamoto',
         city: 'Boston',
@@ -77,6 +90,11 @@ export const exampleBankAccounts = [
         line2: 'Colonia Obrera',
         district: 'México DF',
         postalCode: '06800',
+      },
+      intermediaryBank: {
+        identifier: '',
+        type: '',
+        countryCode: '',
       },
     },
   },

--- a/pages/debug/businessAccount/bankAccounts/create.vue
+++ b/pages/debug/businessAccount/bankAccounts/create.vue
@@ -52,6 +52,12 @@
           />
 
           <v-text-field
+            v-model="formData.ffcMemo"
+            label="FFC Memo"
+            hint="FFC Memo"
+          />
+
+          <v-text-field
             v-model="formData.billingDetails.name"
             label="Billing Name"
           />
@@ -123,6 +129,21 @@
             label="Bank Address Country Code"
           />
 
+          <v-text-field
+            v-model="formData.intermediaryBank.identifier"
+            label="Intermediary Bank Identifier"
+          />
+
+          <v-text-field
+            v-model="formData.intermediaryBank.type"
+            label="Intermediary Bank Identitifer Type"
+            hint="ABA for US domestic accounts, BIC for international"
+          />
+
+          <v-text-field
+            v-model="formData.intermediaryBank.countryCode"
+            label="Intermediary Bank Country Code"
+          />
           <v-btn
             depressed
             color="primary"
@@ -178,6 +199,7 @@ export default class CreateCardClass extends Vue {
     accountNumber: '',
     routingNumber: '',
     iban: '',
+    ffcMemo: '',
     billingDetails: {
       name: '',
       city: '',
@@ -195,6 +217,11 @@ export default class CreateCardClass extends Vue {
       line2: '',
       district: '',
       postalCode: '',
+    },
+    intermediaryBank: {
+      identifier: '',
+      type: '',
+      countryCode: '',
     },
   }
 
@@ -225,9 +252,15 @@ export default class CreateCardClass extends Vue {
 
   async makeApiCall() {
     this.loading = true
-    const { beneficiaryName, accountNumber, routingNumber, iban, ...data } =
-      this.formData
-    const { billingDetails, bankAddress } = data
+    const {
+      beneficiaryName,
+      accountNumber,
+      routingNumber,
+      iban,
+      ffcMemo,
+      ...data
+    } = this.formData
+    const { billingDetails, bankAddress, intermediaryBank } = data
 
     const payload: CreateWireAccountPayload = {
       idempotencyKey: uuidv4(),
@@ -235,6 +268,7 @@ export default class CreateCardClass extends Vue {
       accountNumber,
       routingNumber,
       iban,
+      ffcMemo,
       billingDetails: {
         name: billingDetails.name,
         line1: billingDetails.line1,
@@ -253,6 +287,14 @@ export default class CreateCardClass extends Vue {
         country: bankAddress.country,
         postalCode: bankAddress.postalCode,
       },
+    }
+
+    if (intermediaryBank.identifier.length > 0) {
+      payload.intermediaryBank = {
+        identifier: intermediaryBank.identifier,
+        type: intermediaryBank.type,
+        countryCode: intermediaryBank.countryCode,
+      }
     }
 
     try {


### PR DESCRIPTION
We're adding capability to specify ffcMemo and intermediary bank details during fiat account linking. This PR adds the new fields to the sample app.

<img width="1231" alt="Screenshot 2023-09-21 at 11 08 09" src="https://github.com/circlefin/payments-sample-app/assets/105304719/1b73d83f-0db3-4bd9-8e3f-78e5ea9a6264">
<img width="596" alt="Screenshot 2023-09-21 at 11 08 01" src="https://github.com/circlefin/payments-sample-app/assets/105304719/e6d2dd2b-211b-4607-ab3c-85ff78965bdf">
