### PR TITLE
license cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -172,30 +172,3 @@
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2023 Circle Internet Financial Trading Company Limited
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/assets/applePayButton.css
+++ b/assets/applePayButton.css
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .apple-pay-button {
   width: 250px;
   height: 40px;

--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Ref: https://github.com/nuxt-community/vuetify-module#customvariables
 //
 // The variables you want to modify

--- a/components/AmountInput.vue
+++ b/components/AmountInput.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-text-field
     v-model="amountFormatted"

--- a/components/CVVInput.vue
+++ b/components/CVVInput.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-text-field
     v-mask="vMask"

--- a/components/CardInput.vue
+++ b/components/CardInput.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-text-field
     v-mask="vMask"

--- a/components/ChainSelect.vue
+++ b/components/ChainSelect.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-select
     :value="value"

--- a/components/CountrySelect.vue
+++ b/components/CountrySelect.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-select
     :value="value"

--- a/components/CreateCardForm.vue
+++ b/components/CreateCardForm.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <div>
     <div v-if="showError" class="red--text">

--- a/components/Environment.vue
+++ b/components/Environment.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <div class="overline mb-4" :class="colorClass">{{ env }} ENVIRONMENT</div>
 </template>

--- a/components/ErrorSheet.vue
+++ b/components/ErrorSheet.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-bottom-sheet v-model="bottomSheetValue">
     <v-sheet class="text-center" height="200px">

--- a/components/ExpiryInput.vue
+++ b/components/ExpiryInput.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-text-field
     ref="expiry"

--- a/components/MarketplaceInfoFields.vue
+++ b/components/MarketplaceInfoFields.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <div class="mb-6">
     <v-select

--- a/components/PaymentStatus.vue
+++ b/components/PaymentStatus.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <div>
     <h3>Thank you, we received your payment.</h3>

--- a/components/RequestInfo.vue
+++ b/components/RequestInfo.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <div class="request-info">
     <div v-show="url">

--- a/deploy/aws/buildspec_build.yml
+++ b/deploy/aws/buildspec_build.yml
@@ -1,3 +1,19 @@
+# Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 env:

--- a/deploy/aws/buildspec_deploy.yml
+++ b/deploy/aws/buildspec_deploy.yml
@@ -1,3 +1,19 @@
+# Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 version: 0.2
 
 env:

--- a/devtools/node/.eslintrc.js
+++ b/devtools/node/.eslintrc.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 module.exports = {
   root: true,
   env: {

--- a/helpers/validation.ts
+++ b/helpers/validation.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { validate } from 'uuid'
 const isNumber = (v: string) =>
   v === '' || !isNaN(parseInt(v)) || 'Please enter valid number'

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 module.exports = {
   testEnvironment: 'jsdom',
   moduleNameMapper: {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-app>
     <v-navigation-drawer

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-app dark>
     <h1 v-if="error.statusCode === 404">Page not found</h1>

--- a/lib/addressesApi.ts
+++ b/lib/addressesApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/apiTarget.ts
+++ b/lib/apiTarget.ts
@@ -1,4 +1,22 @@
 /**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
  * Silly hacky way to determine the API endpoint from the current hostname.  Nuxt makes it
  * surprisingly difficult to add serverside runtime environment variables (to then serve to
  * the client via a configuration endpoint), so we're stuck using this.  We can get away with

--- a/lib/applePay.ts
+++ b/lib/applePay.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import axios from 'axios'
 import { getIsStaging } from '~/lib/apiTarget'
 

--- a/lib/beta/addressBookApi.ts
+++ b/lib/beta/addressBookApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/businessAccount/addressesApi.ts
+++ b/lib/businessAccount/addressesApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/businessAccount/balancesApi.ts
+++ b/lib/businessAccount/balancesApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/businessAccount/bankAccountsApi.ts
+++ b/lib/businessAccount/bankAccountsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/businessAccount/bankAccountsTestData.ts
+++ b/lib/businessAccount/bankAccountsTestData.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export const exampleBankAccounts = [
   {
     title: 'US Bank Account',

--- a/lib/businessAccount/cbitAccountsApi.ts
+++ b/lib/businessAccount/cbitAccountsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import axios from 'axios'
 import get from 'lodash/get'
 import { getAPIHostname } from '../apiTarget'

--- a/lib/businessAccount/depositsApi.ts
+++ b/lib/businessAccount/depositsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/businessAccount/payoutsApi.ts
+++ b/lib/businessAccount/payoutsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/businessAccount/rtpAccountsApi.ts
+++ b/lib/businessAccount/rtpAccountsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/businessAccount/transfersApi.ts
+++ b/lib/businessAccount/transfersApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/businessAccount/xpayAccountsApi.ts
+++ b/lib/businessAccount/xpayAccountsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import axios from 'axios'
 import get from 'lodash/get'
 import { getAPIHostname } from '../apiTarget'

--- a/lib/cardTestData.ts
+++ b/lib/cardTestData.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export const exampleCards = [
   {
     title: '4007400000000007 (visa)',

--- a/lib/cardsApi.ts
+++ b/lib/cardsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/chargebacksApi.ts
+++ b/lib/chargebacksApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/checkoutSessionsApi.ts
+++ b/lib/checkoutSessionsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/cryptoPaymentMetadataApi.ts
+++ b/lib/cryptoPaymentMetadataApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/cryptoPaymentsApi.ts
+++ b/lib/cryptoPaymentsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/eventBus.js
+++ b/lib/eventBus.js
@@ -1,2 +1,20 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import Vue from 'vue'
 export const EventBus = new Vue()

--- a/lib/googlePay.ts
+++ b/lib/googlePay.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import axios from 'axios'
 import IsReadyToPayRequest = google.payments.api.IsReadyToPayRequest
 import PaymentDataRequest = google.payments.api.PaymentDataRequest

--- a/lib/marketplaceApi.ts
+++ b/lib/marketplaceApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 import { v4 as uuidv4 } from 'uuid'

--- a/lib/mocksApi.ts
+++ b/lib/mocksApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/navigatorInfo.ts
+++ b/lib/navigatorInfo.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 function getIsSafari() {
   const userAgent = navigator.userAgent
   const vendor = navigator.vendor

--- a/lib/openpgp.ts
+++ b/lib/openpgp.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { createMessage, encrypt as pgpEncrypt, readKey } from 'openpgp'
 
 interface PublicKey {

--- a/lib/paymentIntentsApi.ts
+++ b/lib/paymentIntentsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/paymentsApi.ts
+++ b/lib/paymentsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/payoutsApi.ts
+++ b/lib/payoutsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/settlementsApi.ts
+++ b/lib/settlementsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/transfersApi.ts
+++ b/lib/transfersApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 

--- a/lib/walletConnect.ts
+++ b/lib/walletConnect.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { mainnet, goerli } from '@wagmi/core/chains'
 import { MetaMaskConnector } from '@wagmi/core/connectors/metaMask'
 

--- a/lib/walletsApi.ts
+++ b/lib/walletsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import get from 'lodash/get'
 import axios from 'axios'
 import { v4 as uuidv4 } from 'uuid'

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import colors from 'vuetify/es5/util/colors'
 
 require('dotenv').config()

--- a/pages/debug/beta/addressBook/create.vue
+++ b/pages/debug/beta/addressBook/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/beta/addressBook/delete.vue
+++ b/pages/debug/beta/addressBook/delete.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/beta/addressBook/details.vue
+++ b/pages/debug/beta/addressBook/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/beta/addressBook/fetch.vue
+++ b/pages/debug/beta/addressBook/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/beta/addressBook/patch.vue
+++ b/pages/debug/beta/addressBook/patch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/addresses/deposit/create.vue
+++ b/pages/debug/businessAccount/addresses/deposit/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/addresses/deposit/fetch.vue
+++ b/pages/debug/businessAccount/addresses/deposit/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/addresses/recipient/create.vue
+++ b/pages/debug/businessAccount/addresses/recipient/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/addresses/recipient/fetch.vue
+++ b/pages/debug/businessAccount/addresses/recipient/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/balances/fetch.vue
+++ b/pages/debug/businessAccount/balances/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/bankAccounts/create.vue
+++ b/pages/debug/businessAccount/bankAccounts/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/bankAccounts/details.vue
+++ b/pages/debug/businessAccount/bankAccounts/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/bankAccounts/fetch.vue
+++ b/pages/debug/businessAccount/bankAccounts/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/bankAccounts/instructions.vue
+++ b/pages/debug/businessAccount/bankAccounts/instructions.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/cbitAccounts/create.vue
+++ b/pages/debug/businessAccount/cbitAccounts/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/cbitAccounts/details.vue
+++ b/pages/debug/businessAccount/cbitAccounts/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/cbitAccounts/fetch.vue
+++ b/pages/debug/businessAccount/cbitAccounts/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/cbitAccounts/instructions.vue
+++ b/pages/debug/businessAccount/cbitAccounts/instructions.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/deposits/fetch.vue
+++ b/pages/debug/businessAccount/deposits/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/index.vue
+++ b/pages/debug/businessAccount/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-flex>

--- a/pages/debug/businessAccount/payouts/create.vue
+++ b/pages/debug/businessAccount/payouts/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/payouts/details.vue
+++ b/pages/debug/businessAccount/payouts/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/payouts/fetch.vue
+++ b/pages/debug/businessAccount/payouts/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/rtpAccounts/create.vue
+++ b/pages/debug/businessAccount/rtpAccounts/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/rtpAccounts/details.vue
+++ b/pages/debug/businessAccount/rtpAccounts/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/rtpAccounts/fetch.vue
+++ b/pages/debug/businessAccount/rtpAccounts/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/rtpAccounts/instructions.vue
+++ b/pages/debug/businessAccount/rtpAccounts/instructions.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/transfers/create.vue
+++ b/pages/debug/businessAccount/transfers/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/transfers/details.vue
+++ b/pages/debug/businessAccount/transfers/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/transfers/fetch.vue
+++ b/pages/debug/businessAccount/transfers/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/xpayAccounts/create.vue
+++ b/pages/debug/businessAccount/xpayAccounts/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/xpayAccounts/details.vue
+++ b/pages/debug/businessAccount/xpayAccounts/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/xpayAccounts/fetch.vue
+++ b/pages/debug/businessAccount/xpayAccounts/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/businessAccount/xpayAccounts/instructions.vue
+++ b/pages/debug/businessAccount/xpayAccounts/instructions.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/cards/create.vue
+++ b/pages/debug/cards/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/cards/details.vue
+++ b/pages/debug/cards/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/cards/fetch.vue
+++ b/pages/debug/cards/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/cards/update.vue
+++ b/pages/debug/cards/update.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/chargebacks/details.vue
+++ b/pages/debug/chargebacks/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/chargebacks/fetch.vue
+++ b/pages/debug/chargebacks/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/chargebacks/mocks/create.vue
+++ b/pages/debug/chargebacks/mocks/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/checkoutSessions/create.vue
+++ b/pages/debug/checkoutSessions/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/checkoutSessions/details.vue
+++ b/pages/debug/checkoutSessions/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/checkoutSessions/extend.vue
+++ b/pages/debug/checkoutSessions/extend.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/checkoutSessions/fetch.vue
+++ b/pages/debug/checkoutSessions/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/checkoutSessions/index.vue
+++ b/pages/debug/checkoutSessions/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-flex>

--- a/pages/debug/digitalDollarAccounts/index.vue
+++ b/pages/debug/digitalDollarAccounts/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-flex>

--- a/pages/debug/index.vue
+++ b/pages/debug/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-flex>

--- a/pages/debug/marketplace/merchants/fetch.vue
+++ b/pages/debug/marketplace/merchants/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/marketplace/payments/cancel.vue
+++ b/pages/debug/marketplace/payments/cancel.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/marketplace/payments/capture.vue
+++ b/pages/debug/marketplace/payments/capture.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/marketplace/payments/create.vue
+++ b/pages/debug/marketplace/payments/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/marketplace/payments/details.vue
+++ b/pages/debug/marketplace/payments/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/marketplace/payments/fetch.vue
+++ b/pages/debug/marketplace/payments/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/marketplace/payments/refund.vue
+++ b/pages/debug/marketplace/payments/refund.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/paymentIntents/create.vue
+++ b/pages/debug/paymentIntents/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/paymentIntents/createCryptoRefund.vue
+++ b/pages/debug/paymentIntents/createCryptoRefund.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/paymentIntents/details.vue
+++ b/pages/debug/paymentIntents/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/paymentIntents/expire.vue
+++ b/pages/debug/paymentIntents/expire.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/paymentIntents/fetch.vue
+++ b/pages/debug/paymentIntents/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/paymentIntents/index.vue
+++ b/pages/debug/paymentIntents/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-flex>

--- a/pages/debug/payments/balances/fetch.vue
+++ b/pages/debug/payments/balances/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payments/cancel.vue
+++ b/pages/debug/payments/cancel.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payments/capture.vue
+++ b/pages/debug/payments/capture.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payments/create.vue
+++ b/pages/debug/payments/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payments/crypto/create.vue
+++ b/pages/debug/payments/crypto/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payments/crypto/presign.vue
+++ b/pages/debug/payments/crypto/presign.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payments/details.vue
+++ b/pages/debug/payments/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payments/digitalWallets/paymenttokens.vue
+++ b/pages/debug/payments/digitalWallets/paymenttokens.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payments/fetch.vue
+++ b/pages/debug/payments/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payments/mocks/wire.vue
+++ b/pages/debug/payments/mocks/wire.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payments/refund.vue
+++ b/pages/debug/payments/refund.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payouts/create.vue
+++ b/pages/debug/payouts/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payouts/details.vue
+++ b/pages/debug/payouts/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payouts/fetch.vue
+++ b/pages/debug/payouts/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/payouts/index.vue
+++ b/pages/debug/payouts/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-flex>

--- a/pages/debug/settlements/details.vue
+++ b/pages/debug/settlements/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/settlements/fetch.vue
+++ b/pages/debug/settlements/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/wallets/addresses/create.vue
+++ b/pages/debug/wallets/addresses/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/wallets/addresses/fetch.vue
+++ b/pages/debug/wallets/addresses/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/wallets/index.vue
+++ b/pages/debug/wallets/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-flex>

--- a/pages/debug/wallets/transfers/create.vue
+++ b/pages/debug/wallets/transfers/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/wallets/transfers/details.vue
+++ b/pages/debug/wallets/transfers/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/wallets/transfers/fetch.vue
+++ b/pages/debug/wallets/transfers/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/wallets/wallets/create.vue
+++ b/pages/debug/wallets/wallets/create.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/wallets/wallets/details.vue
+++ b/pages/debug/wallets/wallets/details.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/debug/wallets/wallets/fetch.vue
+++ b/pages/debug/wallets/wallets/fetch.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/flow/card/create/index.vue
+++ b/pages/flow/card/create/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-row>
     <v-col cols="12" md="5">

--- a/pages/flow/charge/existing-card/index.vue
+++ b/pages/flow/charge/existing-card/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/flow/charge/index.vue
+++ b/pages/flow/charge/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-row>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,3 +1,21 @@
+<!--
+ Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+-->
+
 <template>
   <v-layout>
     <v-flex>

--- a/plugins/addressesApi.ts
+++ b/plugins/addressesApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import addressesApi from '@/lib/addressesApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/beta/addressBookApi.ts
+++ b/plugins/beta/addressBookApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import addressBookApiBeta, {
   CreateRecipientPayload,
 } from '@/lib/beta/addressBookApi'

--- a/plugins/businessAccount/addressesApi.ts
+++ b/plugins/businessAccount/addressesApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import addressesApi, {
   CreateRecipientAddressPayload,
   CreateDepositAddressPayload,

--- a/plugins/businessAccount/balancesApi.ts
+++ b/plugins/businessAccount/balancesApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import balancesApi from '@/lib/businessAccount/balancesApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/businessAccount/bankAccountsApi.ts
+++ b/plugins/businessAccount/bankAccountsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import bankAccountsApi, {
   CreateWireAccountPayload,
 } from '@/lib/businessAccount/bankAccountsApi'

--- a/plugins/businessAccount/cbitAccountsApi.ts
+++ b/plugins/businessAccount/cbitAccountsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import cbitAccountsApi, {
   CreateCbitAccountPayload,
 } from '@/lib/businessAccount/cbitAccountsApi'

--- a/plugins/businessAccount/depositsApi.ts
+++ b/plugins/businessAccount/depositsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import depositsApi from '@/lib/businessAccount/depositsApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/businessAccount/payoutsApi.ts
+++ b/plugins/businessAccount/payoutsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import payoutsApi, {
   CreatePayoutPayload,
 } from '@/lib/businessAccount/payoutsApi'

--- a/plugins/businessAccount/rtpAccountsApi.ts
+++ b/plugins/businessAccount/rtpAccountsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import rtpAccountsApi, {
   CreateRTPAccountPayload,
 } from '@/lib/businessAccount/rtpAccountsApi'

--- a/plugins/businessAccount/transfersApi.ts
+++ b/plugins/businessAccount/transfersApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import transfersApi, {
   CreateTransferPayload,
 } from '@/lib/businessAccount/transfersApi'

--- a/plugins/businessAccount/xpayAccountsApi.ts
+++ b/plugins/businessAccount/xpayAccountsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import xpayAccountsApi, {
   CreateXpayAccountPayload,
 } from '@/lib/businessAccount/xpayAccountsApi'

--- a/plugins/cardsApi.ts
+++ b/plugins/cardsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import cardsApi, { CreateCardPayload, UpdateCardPayload } from '@/lib/cardsApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/chargebacksApi.ts
+++ b/plugins/chargebacksApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import chargebacksApi from '@/lib/chargebacksApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/checkoutSessionsApi.ts
+++ b/plugins/checkoutSessionsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import checkoutSessionsAPI, {
   CreateCheckoutSessionPayload,
 } from '@/lib/checkoutSessionsApi'

--- a/plugins/cryptoPaymentMetadataApi.ts
+++ b/plugins/cryptoPaymentMetadataApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import cryptoPaymentMetadataApi from '@/lib/cryptoPaymentMetadataApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/cryptoPaymentsApi.ts
+++ b/plugins/cryptoPaymentsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import paymentsApiBeta, {
   CreateCryptoPaymentPayload,
 } from '@/lib/cryptoPaymentsApi'

--- a/plugins/marketplaceApi.ts
+++ b/plugins/marketplaceApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import marketplaceApi, { BasePaymentPayload } from '@/lib/marketplaceApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/mocksApi.ts
+++ b/plugins/mocksApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import mocksApi, {
   CreateMockChargebackPayload,
   CreateMockPushPaymentPayload,

--- a/plugins/paymentIntentsApi.ts
+++ b/plugins/paymentIntentsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import paymentIntentsAPI, {
   CreateTransientPaymentIntentPayload,
   CreateContinuousPaymentIntentPayload,

--- a/plugins/paymentsApi.ts
+++ b/plugins/paymentsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import paymentsApi, { BasePaymentPayload } from '@/lib/paymentsApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/payoutsApi.ts
+++ b/plugins/payoutsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import payoutsApi, { CreatePayoutPayload } from '@/lib/payoutsApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/settlementsApi.ts
+++ b/plugins/settlementsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import settlementsApi from '@/lib/settlementsApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/transfersApi.ts
+++ b/plugins/transfersApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import transfersApi, { CreateTransferPayload } from '@/lib/transfersApi'
 
 declare module 'vue/types/vue' {

--- a/plugins/walletsApi.ts
+++ b/plugins/walletsApi.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import walletsApi from '@/lib/walletsApi'
 
 declare module 'vue/types/vue' {

--- a/server-middleware/apiApplePay.ts
+++ b/server-middleware/apiApplePay.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as https from 'https'
 import axios from 'axios'
 import express from 'express'

--- a/server-middleware/apiGooglePay.ts
+++ b/server-middleware/apiGooglePay.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import express from 'express'
 import { merchantId, merchantName, checkoutKey } from './googlePaySecrets'
 

--- a/server-middleware/applePaySettings.ts
+++ b/server-middleware/applePaySettings.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const payfacMerchantIdentityCertificate: string =
   process.env.APPLE_PAY_PAYFAC_CERTIFICATE != null
     ? process.env.APPLE_PAY_PAYFAC_CERTIFICATE!

--- a/server-middleware/domainVerification.ts
+++ b/server-middleware/domainVerification.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import express from 'express'
 import { domainValidation } from './applePaySettings'
 

--- a/server-middleware/googlePaySecrets.ts
+++ b/server-middleware/googlePaySecrets.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const merchantId: string =
   process.env.GOOGLE_PAY_PAYFAC_MERCHANT_ID != null
     ? process.env.GOOGLE_PAY_PAYFAC_MERCHANT_ID!

--- a/server-middleware/serverEnv.ts
+++ b/server-middleware/serverEnv.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /*
 public API endpoints per environment
 api.circle.com

--- a/server/api.ts
+++ b/server/api.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { ServerMiddleware } from '@nuxt/types'
 
 const pingHandler: ServerMiddleware = (_req, res) => {

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const express = require('express')
 const consola = require('consola')
 const { Nuxt, Builder } = require('nuxt')

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import VuexPersist from 'vuex-persist'
 import { MutationTree, GetterTree, ActionTree } from 'vuex'
 

--- a/test/unit/lib/apiTarget.spec.js
+++ b/test/unit/lib/apiTarget.spec.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Circle Internet Financial, LTD.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { getAPIHostname, getLive } from '@/lib/apiTarget'
 
 describe('apiTarget', () => {


### PR DESCRIPTION
* remove short-form license header text from bottom of LICENSE
* add short form license to sources where it was lacking
* include SPDX-License-Identifier tag in header