### PR TITLE
[UNTRACKED] Add SEPA destination for create Payouts page

### DIFF
--- a/pages/debug/businessAccount/payouts/create.vue
+++ b/pages/debug/businessAccount/payouts/create.vue
@@ -79,18 +79,20 @@ export default class CreatePayoutClass extends Vue {
   }
 
   required = [(v: string) => !!v || 'Field is required']
-  destinationType = ['wire', 'cbit', 'xpay', 'rtp', 'rtgs']
+  destinationType = ['wire', 'cbit', 'xpay', 'rtp', 'rtgs', 'sepa']
   wireCurrencyTypes = ['USD', 'EUR']
   cbitCurrencyTypes = ['USD']
   xpayCurrencyTypes = ['USD']
   rtpCurrencyTypes = ['USD']
   rtgsCurrencyTypes = ['USD', 'EUR']
+  sepaCurrencyTypes = ['EUR']
   currencyTypes = new Map([
     ['wire', this.wireCurrencyTypes],
     ['cbit', this.cbitCurrencyTypes],
     ['xpay', this.xpayCurrencyTypes],
     ['rtp', this.rtpCurrencyTypes],
     ['rtgs', this.rtgsCurrencyTypes],
+    ['sepa', this.sepaCurrencyTypes],
   ])
 
   error = {}


### PR DESCRIPTION
SEPA is a new rail that we are supporting as a destination for business account payouts. This PR adds it to the sample app. 