### PR TITLE
[Untracked] Add sepa/sepa instant support to mock payments

### DIFF
--- a/lib/apiTarget.ts
+++ b/lib/apiTarget.ts
@@ -14,6 +14,11 @@ function getAPIHostname() {
   return window.location.origin.replace('sample', 'api')
 }
 
+function getIsInternal() {
+  const hostname = getAPIHostname()
+  return hostname!.includes('staging') || hostname!.includes('smokebox')
+}
+
 function getLive() {
   const hostname = getAPIHostname()
   return !(hostname!.includes('sandbox') || hostname!.includes('smokebox'))
@@ -29,4 +34,4 @@ function getIsLocalHost(): boolean {
   return hostname!.includes(':3011')
 }
 
-export { getAPIHostname, getLive, getIsStaging, getIsLocalHost }
+export { getAPIHostname, getIsInternal, getLive, getIsStaging, getIsLocalHost }

--- a/pages/debug/payments/mocks/wire.vue
+++ b/pages/debug/payments/mocks/wire.vue
@@ -74,7 +74,7 @@ export default class CreateMockIncomingWireClass extends Vue {
 
   currencyTypes = ['USD', 'EUR', 'SGD', 'MXN']
 
-  rails = ['wire', 'rtgs', 'spei']
+  rails = ['wire', 'rtgs', 'spei', 'sepa', 'sepa_instant']
 
   isSandbox: Boolean = !getLive()
   required = [(v: string) => !!v || 'Field is required']

--- a/pages/debug/payments/mocks/wire.vue
+++ b/pages/debug/payments/mocks/wire.vue
@@ -46,7 +46,7 @@
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator'
 import { mapGetters } from 'vuex'
-import { getLive } from '../../../../lib/apiTarget'
+import { getIsInternal, getLive } from '../../../../lib/apiTarget'
 import RequestInfo from '../../../../components/RequestInfo.vue'
 import ErrorSheet from '../../../../components/ErrorSheet.vue'
 import { CreateMockPushPaymentPayload } from '~/lib/mocksApi'
@@ -74,7 +74,9 @@ export default class CreateMockIncomingWireClass extends Vue {
 
   currencyTypes = ['USD', 'EUR', 'SGD', 'MXN']
 
-  rails = ['wire', 'rtgs', 'spei', 'sepa', 'sepa_instant']
+  rails = getIsInternal()
+    ? ['wire', 'rtgs', 'spei', 'sepa', 'sepa_instant']
+    : ['wire', 'rtgs', 'spei', 'sepa']
 
   isSandbox: Boolean = !getLive()
   required = [(v: string) => !!v || 'Field is required']

--- a/test/unit/lib/apiTarget.spec.js
+++ b/test/unit/lib/apiTarget.spec.js
@@ -1,4 +1,4 @@
-import { getAPIHostname, getLive } from '@/lib/apiTarget'
+import { getAPIHostname, getIsInternal, getLive } from '@/lib/apiTarget'
 
 describe('apiTarget', () => {
   beforeEach(() => {
@@ -25,17 +25,21 @@ describe('apiTarget', () => {
     window.location.origin = 'sample.circle.com'
     expect(getAPIHostname()).toStrictEqual('api.circle.com')
     expect(getLive()).toBeTruthy()
+    expect(getIsInternal()).toBeFalsy()
 
     window.location.origin = 'sample-staging.circle.com'
     expect(getAPIHostname()).toStrictEqual('api-staging.circle.com')
     expect(getLive()).toBeTruthy()
+    expect(getIsInternal()).toBeTruthy()
 
     window.location.origin = 'sample-sandbox.circle.com'
     expect(getAPIHostname()).toStrictEqual('api-sandbox.circle.com')
     expect(getLive()).toBeFalsy()
+    expect(getIsInternal()).toBeFalsy()
 
     window.location.origin = 'sample-smokebox.circle.com'
     expect(getAPIHostname()).toStrictEqual('api-smokebox.circle.com')
     expect(getLive()).toBeFalsy()
+    expect(getIsInternal()).toBeTruthy()
   })
 })


### PR DESCRIPTION
Banking Circle only supports sepa and sepa_instant rails, to test mock payments on smokebox/sandbox via the sample app we need options for these new rails