### PR TITLE
BANK-2668 Add support for mock wire payment memo

### DIFF
--- a/lib/mocksApi.ts
+++ b/lib/mocksApi.ts
@@ -5,6 +5,7 @@ import { getAPIHostname } from './apiTarget'
 
 export interface CreateMockPushPaymentPayload {
   trackingRef: string
+  memo: string
   beneficiaryBank: {
     accountNumber: string
   }

--- a/pages/debug/payments/mocks/wire.vue
+++ b/pages/debug/payments/mocks/wire.vue
@@ -4,6 +4,7 @@
       <v-col cols="12" md="4">
         <v-form>
           <v-text-field v-model="formData.trackingRef" label="Tracking Ref" />
+          <v-text-field v-model="formData.memo" label="External Ref" />
           <v-text-field
             v-model="formData.accountNumber"
             label="Account Number"
@@ -66,6 +67,7 @@ import { CreateMockPushPaymentPayload } from '~/lib/mocksApi'
 export default class CreateMockIncomingWireClass extends Vue {
   formData = {
     trackingRef: '',
+    memo: '',
     accountNumber: '',
     amount: '0.00',
     currency: 'USD', // Default to USD
@@ -96,6 +98,7 @@ export default class CreateMockIncomingWireClass extends Vue {
     }
     const payload: CreateMockPushPaymentPayload = {
       trackingRef: this.formData.trackingRef,
+      memo: this.formData.memo,
       beneficiaryBank: {
         accountNumber: this.formData.accountNumber,
       },


### PR DESCRIPTION
Since adding a memo to push payments other than the customer tracking ref is a common use case, we want to add this support to the mock wire page.

This specifically allows OKX (and other mint for exchanges customers) to test adding an external ref to their push payments.

**Tested via API**

EFT PR: https://github.com/circlefin/platform-eft/pull/7219