### PR TITLE
BANK-2668 Update memo label

### DIFF
--- a/pages/debug/payments/mocks/wire.vue
+++ b/pages/debug/payments/mocks/wire.vue
@@ -4,7 +4,7 @@
       <v-col cols="12" md="4">
         <v-form>
           <v-text-field v-model="formData.trackingRef" label="Tracking Ref" />
-          <v-text-field v-model="formData.memo" label="External Ref" />
+          <v-text-field v-model="formData.memo" label="Memo" />
           <v-text-field
             v-model="formData.accountNumber"
             label="Account Number"


### PR DESCRIPTION
The label for the memo field is still set to external ref, this should be updated.

Related PR: https://github.com/circlefin/payments-sample-app/pull/371