### PR TITLE
[BANK-5155] Bump TMP Transitive Dependency to Resolve Security Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
     "vue-the-mask": "^0.11.1",
     "vuex-persist": "3.1.3"
   },
+  "resolutions": {
+    "tmp": ">=0.2.4",
+    "external-editor/tmp": ">=0.2.4"
+  },
   "devDependencies": {
     "@nuxt/types": "^2.15.8",
     "@nuxt/typescript-build": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11161,7 +11161,7 @@ os-homedir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -14101,12 +14101,10 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
+tmp@>=0.2.4, tmp@^0.0.33:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.4.tgz#c6db987a2ccc97f812f17137b36af2b6521b0d13"
+  integrity sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==
 
 tmpl@1.0.x:
   version "1.0.5"


### PR DESCRIPTION
The pipeline for this repo seems to be failing a [security update](https://github.com/circlefin/payments-sample-app/actions/runs/16790262303/job/47550375468)

The vulnerability is in a transitive dependency called `tmp` which nuxt uses at version 0.0.33 and the lowest non-vulnerable version is 0.2.4

A long term solution would be to update Nuxt to version 3, but this requires much more effort. As a short term fix, add a yarn resolution to require tmp version >= 0.2.4