### PR TITLE
chore: add start command

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -28,7 +28,7 @@ jobs:
   scan:
     needs: test
     if: github.event_name == 'pull_request'
-    uses: circlefin/circle-public-github-workflows/.github/workflows/pr-scan.yaml@fix-pr-scan
+    uses: circlefin/circle-public-github-workflows/.github/workflows/pr-scan.yaml@v1
 
   release-sbom:
     needs: test

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
+    "start": "NODE_ENV=production nuxt start",
     "postinstall": "nuxt prepare",
     "lint": "eslint --ext .ts,.js,.vue .",
     "test": "jest",


### PR DESCRIPTION
The start command was removed in this PR: https://github.com/circlefin/payments-sample-app/pull/405

The container is now erroring with:
```
! Corepack is about to download https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz
yarn run v1.22.22
error Command "start" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```