### PR TITLE
[BANK-5431] Update CPS APIs

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -456,6 +456,10 @@ const cpsTradesLinks = [
     to: '/debug/cps/details',
   },
   {
+    title: 'GET /cps/signatures/presign',
+    to: '/debug/cps/presign',
+  },
+  {
     title: 'POST /cps/signatures',
     to: '/debug/cps/signature',
   },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -463,6 +463,10 @@ const cpsTradesLinks = [
     title: 'POST /cps/signatures',
     to: '/debug/cps/signature',
   },
+  {
+    title: 'POST /cps/signatures/funding/presign',
+    to: '/debug/cps/funding-presign',
+  },
 ]
 
 const miniVariant = ref(false)

--- a/pages/debug/cps/fetch.vue
+++ b/pages/debug/cps/fetch.vue
@@ -1,17 +1,43 @@
 <template>
-  <v-layout>
+  <v-container>
     <v-row>
       <v-col cols="12" md="4">
-        <v-btn
-          depressed
-          class="mb-7"
-          color="primary"
-          :loading="loading"
-          :disabled="loading"
-          @click.prevent="makeApiCall"
-        >
-          Make api call
-        </v-btn>
+        <v-form>
+          <header>Optional filter params:</header>
+          <v-select
+            v-model="formData.statuses"
+            :items="statusOptions"
+            label="Status"
+            clearable
+          />
+          <v-select
+            v-model="formData.type"
+            :items="typeOptions"
+            label="Type"
+            clearable
+          />
+          <v-text-field
+            v-model="formData.startCreateDateInclusive"
+            label="Start Create Date (Inclusive)"
+          />
+          <v-text-field
+            v-model="formData.endCreateDateInclusive"
+            label="End Create Date (Inclusive)"
+          />
+          <v-text-field v-model="formData.pageSize" label="PageSize" />
+          <v-text-field v-model="formData.pageBefore" label="PageBefore" />
+          <v-text-field v-model="formData.pageAfter" label="PageAfter" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            :disabled="loading"
+            @click.prevent="makeApiCall"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
       </v-col>
       <v-col cols="12" md="8">
         <RequestInfo
@@ -26,12 +52,37 @@
       :show-error="showError"
       @on-change="onErrorSheetClosed"
     />
-  </v-layout>
+  </v-container>
 </template>
 
 <script setup lang="ts">
 const store = useMainStore()
 const { $cpsTradesApi } = useNuxtApp()
+
+const statusOptions = [
+  'pending',
+  'confirmed',
+  'pending_settlement',
+  'complete',
+  'failed',
+  'terminated',
+  'breaching',
+  'breached',
+  'taker_funded',
+  'maker_funded',
+]
+
+const typeOptions = ['taker', 'maker']
+
+const formData = reactive({
+  startCreateDateInclusive: '',
+  endCreateDateInclusive: '',
+  statuses: '',
+  type: '',
+  pageSize: '',
+  pageBefore: '',
+  pageAfter: '',
+})
 
 const error = ref<any>({})
 const loading = ref(false)
@@ -49,7 +100,15 @@ const onErrorSheetClosed = () => {
 const makeApiCall = async () => {
   loading.value = true
   try {
-    await $cpsTradesApi.getTrades()
+    await $cpsTradesApi.getTrades(
+      formData.startCreateDateInclusive,
+      formData.endCreateDateInclusive,
+      formData.statuses,
+      formData.type,
+      formData.pageAfter,
+      formData.pageBefore,
+      formData.pageSize,
+    )
   } catch (err) {
     error.value = err
     showError.value = true

--- a/pages/debug/cps/funding-presign.vue
+++ b/pages/debug/cps/funding-presign.vue
@@ -3,26 +3,39 @@
     <v-row>
       <v-col cols="12" md="4">
         <v-form v-model="validForm">
-          <v-text-field
-            v-model="formData.tradeId"
-            :rules="[required]"
-            label="CPS Trade ID"
-          />
           <v-select
-            v-model="formData.type"
-            :items="typeOptions"
-            label="Type (optional)"
-            clearable
+            v-model="formData.traderType"
+            :items="traderTypeOptions"
+            :rules="[required]"
+            label="Trader Type"
           />
+
+          <v-select
+            v-model="formData.fundingMode"
+            :items="fundingModeOptions"
+            :rules="[required]"
+            label="Funding Mode"
+          />
+
+          <v-text-field
+            v-model="formData.contractTradeIds"
+            :rules="[required]"
+            label="Contract Trade IDs"
+            placeholder="Enter comma-separated trade IDs (e.g., id1, id2, id3)"
+            hint="Separate multiple trade IDs with commas"
+            persistent-hint
+          />
+
           <v-btn
             variant="flat"
             class="mb-7"
             color="primary"
             :loading="loading"
             :disabled="!validForm || loading"
+            block
             @click.prevent="makeApiCall"
           >
-            Make api call
+            Get Funding Presign Data
           </v-btn>
         </v-form>
       </v-col>
@@ -43,19 +56,28 @@
 </template>
 
 <script setup lang="ts">
+import type { FundingPresignPayload } from '~/lib/cpsTradesApi'
+
 const store = useMainStore()
 const { $cpsTradesApi } = useNuxtApp()
 
 const validForm = ref(false)
 const formData = reactive({
-  tradeId: '',
-  type: '',
+  contractTradeIds: '',
+  fundingMode: '' as 'gross' | 'net' | '',
+  traderType: '' as 'maker' | 'taker' | '',
 })
 
-const typeOptions = [
-  { title: 'Taker', value: 'taker' },
+const traderTypeOptions = [
   { title: 'Maker', value: 'maker' },
+  { title: 'Taker', value: 'taker' },
 ]
+
+const fundingModeOptions = [
+  { title: 'Gross', value: 'gross' },
+  { title: 'Net', value: 'net' },
+]
+
 const error = ref<any>({})
 const loading = ref(false)
 const showError = ref(false)
@@ -75,7 +97,19 @@ const makeApiCall = async () => {
   loading.value = true
 
   try {
-    await $cpsTradesApi.getTrade(formData.tradeId, formData.type || undefined)
+    // Parse comma-separated trade IDs and trim whitespace
+    const contractTradeIds = formData.contractTradeIds
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id !== '')
+
+    const payloadData: FundingPresignPayload = {
+      contractTradeIds,
+      fundingMode: formData.fundingMode as 'gross' | 'net',
+      traderType: formData.traderType as 'maker' | 'taker',
+    }
+
+    await $cpsTradesApi.getFundingPresignData(payloadData)
   } catch (err) {
     error.value = err
     showError.value = true

--- a/pages/debug/cps/index.vue
+++ b/pages/debug/cps/index.vue
@@ -42,6 +42,14 @@
           <v-chip small color="primary warning">POST</v-chip>
           <a href="/debug/cps/signature">Register CPS signature</a>
         </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/cps/presign">Get presign data for trade</a>
+        </p>
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/cps/funding-presign">Get presign data for funding</a>
+        </p>
       </v-card>
     </v-col>
   </v-container>

--- a/pages/debug/cps/presign.vue
+++ b/pages/debug/cps/presign.vue
@@ -3,16 +3,22 @@
     <v-row>
       <v-col cols="12" md="4">
         <v-form v-model="validForm">
-          <v-text-field
-            v-model="formData.tradeId"
-            :rules="[required]"
-            label="CPS Trade ID"
-          />
           <v-select
             v-model="formData.type"
             :items="typeOptions"
-            label="Type (optional)"
-            clearable
+            :rules="[required]"
+            label="Type"
+          />
+          <v-text-field
+            v-model="formData.tradeId"
+            :rules="[required]"
+            label="Trade ID"
+          />
+          <v-text-field
+            v-if="formData.type === 'taker'"
+            v-model="formData.recipientAddress"
+            :rules="formData.type === 'taker' ? [required] : []"
+            label="Recipient Address"
           />
           <v-btn
             variant="flat"
@@ -22,7 +28,7 @@
             :disabled="!validForm || loading"
             @click.prevent="makeApiCall"
           >
-            Make api call
+            Get Presign Data
           </v-btn>
         </v-form>
       </v-col>
@@ -48,14 +54,16 @@ const { $cpsTradesApi } = useNuxtApp()
 
 const validForm = ref(false)
 const formData = reactive({
-  tradeId: '',
   type: '',
+  tradeId: '',
+  recipientAddress: '',
 })
 
 const typeOptions = [
   { title: 'Taker', value: 'taker' },
   { title: 'Maker', value: 'maker' },
 ]
+
 const error = ref<any>({})
 const loading = ref(false)
 const showError = ref(false)
@@ -75,7 +83,13 @@ const makeApiCall = async () => {
   loading.value = true
 
   try {
-    await $cpsTradesApi.getTrade(formData.tradeId, formData.type || undefined)
+    const recipientAddress =
+      formData.type === 'taker' ? formData.recipientAddress : undefined
+    await $cpsTradesApi.getPresignData(
+      formData.type,
+      formData.tradeId,
+      recipientAddress,
+    )
   } catch (err) {
     error.value = err
     showError.value = true

--- a/pages/debug/cps/signature.vue
+++ b/pages/debug/cps/signature.vue
@@ -20,8 +20,9 @@
             label="Address"
           />
           <v-text-field
+            v-if="formData.type === 'taker'"
             v-model="formData.details.recipient"
-            :rules="[required]"
+            :rules="formData.type === 'taker' ? [required] : []"
             label="Recipient Address"
           />
           <v-text-field
@@ -34,6 +35,12 @@
             v-model="formData.details.nonce"
             :rules="[required, isNumber]"
             label="Nonce"
+            type="number"
+          />
+          <v-text-field
+            v-model="formData.fee"
+            :rules="[required, isNumber]"
+            label="Fee"
             type="number"
           />
           <v-divider class="my-4" />
@@ -128,6 +135,7 @@ const formData = reactive({
       maturity: '',
     },
   },
+  fee: '',
   signature: '',
 })
 
@@ -152,23 +160,30 @@ const makeApiCall = async () => {
   loading.value = true
 
   try {
+    const details: any = {
+      deadline: parseInt(formData.details.deadline),
+      nonce: parseInt(formData.details.nonce),
+      fee: parseInt(formData.fee),
+      consideration: {
+        quoteId: formData.details.consideration.quoteId,
+        base: formData.details.consideration.base,
+        quote: formData.details.consideration.quote,
+        quoteAmount: parseInt(formData.details.consideration.quoteAmount),
+        baseAmount: parseInt(formData.details.consideration.baseAmount),
+        maturity: parseInt(formData.details.consideration.maturity),
+      },
+    }
+
+    // Only include recipient if type is taker
+    if (formData.type === 'taker') {
+      details.recipient = formData.details.recipient
+    }
+
     const payloadData: CreatePiFXSignaturePayload = {
       tradeId: formData.tradeId,
       type: formData.type,
       address: formData.address,
-      details: {
-        recipient: formData.details.recipient,
-        deadline: parseInt(formData.details.deadline),
-        nonce: parseInt(formData.details.nonce),
-        consideration: {
-          quoteId: formData.details.consideration.quoteId,
-          base: formData.details.consideration.base,
-          quote: formData.details.consideration.quote,
-          quoteAmount: parseInt(formData.details.consideration.quoteAmount),
-          baseAmount: parseInt(formData.details.consideration.baseAmount),
-          maturity: parseInt(formData.details.consideration.maturity),
-        },
-      },
+      details,
       signature: formData.signature,
     }
 


### PR DESCRIPTION
There are a few updates since we last added CPS APIs to sample app.

- Add query parameters for GET /pifx/trades and GET /pifx/trades/:id APIs
- Add the new Presign APIs for getting trade typed data and funding typed data
- Small updates to the Register Signature Form (adding Fee)
