### PR TITLE
[DAE-1525] Remove Type and RecipientAddress from Presign API

### DIFF
--- a/lib/stablefxTradesApi.ts
+++ b/lib/stablefxTradesApi.ts
@@ -51,7 +51,6 @@ export interface StableFXPermit2TradeMessage {
 
 export interface CreatePiFXSignaturePayload {
   tradeId: string
-  type: string
   address: string
   details: StableFXPermit2TradeMessage
   signature: string
@@ -206,15 +205,9 @@ function registerSignature(payload: CreatePiFXSignaturePayload) {
 /**
  * Get presign data for signing
  */
-function getPresignData(
-  type: string,
-  tradeId: string,
-  recipientAddress?: string,
-) {
-  const url = `/v1/exchange/stablefx/signatures/presign/${type}/${tradeId}`
-  const queryParams = recipientAddress ? { recipientAddress } : {}
-
-  return instance.get(url, { params: queryParams })
+function getPresignData(tradeId: string) {
+  const url = `/v1/exchange/stablefx/signatures/presign/${tradeId}`
+  return instance.get(url)
 }
 
 /**

--- a/pages/debug/stablefx/presign.vue
+++ b/pages/debug/stablefx/presign.vue
@@ -3,22 +3,10 @@
     <v-row>
       <v-col cols="12" md="4">
         <v-form v-model="validForm">
-          <v-select
-            v-model="formData.type"
-            :items="typeOptions"
-            :rules="[required]"
-            label="Type"
-          />
           <v-text-field
             v-model="formData.tradeId"
             :rules="[required]"
             label="Trade ID"
-          />
-          <v-text-field
-            v-if="formData.type === 'taker'"
-            v-model="formData.recipientAddress"
-            :rules="formData.type === 'taker' ? [required] : []"
-            label="Recipient Address"
           />
           <v-row class="mb-7">
             <v-col cols="12" sm="6">
@@ -118,15 +106,8 @@ const router = useRouter()
 
 const validForm = ref(false)
 const formData = reactive({
-  type: '',
   tradeId: (route.query.tradeId as string) || '',
-  recipientAddress: '',
 })
-
-const typeOptions = [
-  { title: 'Taker', value: 'taker' },
-  { title: 'Maker', value: 'maker' },
-]
 
 const error = ref<any>({})
 const loading = ref(false)
@@ -167,13 +148,7 @@ const makeApiCall = async () => {
   signatureResult.value = '' // Clear previous signature result
 
   try {
-    const recipientAddress =
-      formData.type === 'taker' ? formData.recipientAddress : undefined
-    await $stablefxTradesApi.getPresignData(
-      formData.type,
-      formData.tradeId,
-      recipientAddress,
-    )
+    await $stablefxTradesApi.getPresignData(formData.tradeId)
   } catch (err) {
     error.value = err
     showError.value = true
@@ -270,7 +245,6 @@ const goToRegisterSignature = () => {
       tradeId: formData.tradeId,
       signature: signatureResult.value,
       typedDataMessage: typedDataMessage,
-      type: formData.type,
     },
   })
 }

--- a/pages/debug/stablefx/signature.vue
+++ b/pages/debug/stablefx/signature.vue
@@ -8,12 +8,6 @@
             :rules="[required]"
             label="Trade ID"
           />
-          <v-select
-            v-model="formData.type"
-            :items="['maker', 'taker']"
-            :rules="[required]"
-            label="Trader Type"
-          />
           <v-text-field
             v-model="formData.address"
             :rules="[required]"
@@ -81,7 +75,6 @@ const validForm = ref(false)
 const registrationSuccess = ref(false)
 const formData = reactive({
   tradeId: (route.query.tradeId as string) || '',
-  type: (route.query.type as string) || '',
   address: '',
   signature: (route.query.signature as string) || '',
   typedDataMessage: (route.query.typedDataMessage as string) || '',
@@ -121,7 +114,6 @@ const makeApiCall = async () => {
 
     const payloadData: CreatePiFXSignaturePayload = {
       tradeId: formData.tradeId,
-      type: formData.type,
       address: formData.address,
       details: parsedMessage,
       signature: formData.signature,
@@ -142,7 +134,6 @@ const goToTradeDetails = () => {
     path: '/debug/stablefx/details',
     query: {
       tradeId: formData.tradeId,
-      type: formData.type,
     },
   })
 }


### PR DESCRIPTION
Going forward, this API will only be used for Makers to register their signature.
We can remove inputs for `type` and `recipientAddress`