### PR TITLE
feat(CMP-691): add optional `lei` field to address book recipient creation

### DIFF
--- a/lib/beta/addressBookApi.ts
+++ b/lib/beta/addressBookApi.ts
@@ -12,13 +12,13 @@ export interface CreateRecipientPayload {
     email: string
     bns: string
     nickname: string
+    lei?: string
   }
   identity?: {
     type: string
     firstName?: string
     lastName?: string
     businessName?: string
-    lei?: string
   }
   walletId?: string
   ownership?: {

--- a/lib/beta/addressBookApi.ts
+++ b/lib/beta/addressBookApi.ts
@@ -18,6 +18,7 @@ export interface CreateRecipientPayload {
     firstName?: string
     lastName?: string
     businessName?: string
+    lei?: string
   }
   walletId?: string
   ownership?: {

--- a/pages/debug/addressBook/create.vue
+++ b/pages/debug/addressBook/create.vue
@@ -54,6 +54,11 @@
             v-model="formData.businessName"
             label="Business Name"
           />
+          <v-text-field
+            v-if="formData.identityType === 'business'"
+            v-model="formData.lei"
+            label="LEI (optional)"
+          />
 
           <div class="text-subtitle-2 mb-2">Ownership (optional)</div>
           <v-select
@@ -121,6 +126,7 @@ const formData = reactive({
   firstName: '',
   lastName: '',
   businessName: '',
+  lei: '',
   ownershipType: '',
   custodyType: '',
   vaspId: '',
@@ -184,6 +190,7 @@ const makeApiCall = async () => {
       }),
       ...(formData.identityType === 'business' && {
         businessName: formData.businessName || undefined,
+        lei: formData.lei || undefined,
       }),
     }
   }

--- a/pages/debug/addressBook/create.vue
+++ b/pages/debug/addressBook/create.vue
@@ -170,6 +170,7 @@ const makeApiCall = async () => {
       email: formData.email,
       bns: formData.bns,
       nickname: formData.nickname,
+      ...(formData.lei && { lei: formData.lei }),
     },
   }
 
@@ -190,7 +191,6 @@ const makeApiCall = async () => {
       }),
       ...(formData.identityType === 'business' && {
         businessName: formData.businessName || undefined,
-        lei: formData.lei || undefined,
       }),
     }
   }


### PR DESCRIPTION
## Summary
- Adds optional `lei` field to `CreateRecipientPayload.metadata` in `lib/beta/addressBookApi.ts`.
- Adds an LEI text input to the debug Address Book create form (shown under the business identity section) and forwards the value as `metadata.lei` when present.

Ticket: [CMP-691](https://circlepay.atlassian.net/browse/CMP-691)

## Test plan
- [ ] Open the debug Address Book create page and verify the LEI input appears only when identity type is **business**.
- [ ] Submit a recipient with an LEI and confirm the value is sent at `metadata.lei` (not under `identity`).
- [ ] Submit a recipient without an LEI and confirm `lei` is omitted from `metadata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CMP-691]: https://circlepay.atlassian.net/browse/CMP-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ