### PR TITLE
[CMP-686] feat: add verification cancel and resend addressBook pages

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -559,6 +559,10 @@ const walletId = computed({
 <style scoped>
 .list-items {
   font-size: 14px;
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  word-break: break-all;
 }
 .pointer {
   cursor: pointer;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -413,6 +413,14 @@ const payoutsLinks = [
     to: '/debug/addressBook/vasps',
   },
   {
+    title: 'POST /addressBook/recipients/{id}/verification/cancel',
+    to: '/debug/addressBook/verificationCancel',
+  },
+  {
+    title: 'POST /addressBook/recipients/{id}/verification/resend',
+    to: '/debug/addressBook/verificationResend',
+  },
+  {
     title: 'POST /payouts',
     to: '/debug/payouts/create',
   },

--- a/lib/beta/addressBookApi.ts
+++ b/lib/beta/addressBookApi.ts
@@ -159,6 +159,24 @@ function getVasps() {
   return instance.get(url)
 }
 
+/**
+ * Cancel a self-hosted wallet verification session for a recipient.
+ * @param {String} addressId
+ */
+function cancelVerification(addressId: string) {
+  const url = `/v1/addressBook/recipients/${addressId}/verification/cancel`
+  return instance.post(url)
+}
+
+/**
+ * Resend the self-hosted wallet verification email for a recipient.
+ * @param {String} addressId
+ */
+function resendVerification(addressId: string) {
+  const url = `/v1/addressBook/recipients/${addressId}/verification/resend`
+  return instance.post(url)
+}
+
 export default {
   getInstance,
   getRecipients,
@@ -167,4 +185,6 @@ export default {
   patchRecipient,
   deleteRecipient,
   getVasps,
+  cancelVerification,
+  resendVerification,
 }

--- a/pages/debug/addressBook/verificationCancel.vue
+++ b/pages/debug/addressBook/verificationCancel.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.addressId" label="Address Id" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $addressBookApiBeta } = useNuxtApp()
+
+const formData = reactive({
+  addressId: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $addressBookApiBeta.cancelVerification(formData.addressId)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/addressBook/verificationResend.vue
+++ b/pages/debug/addressBook/verificationResend.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.addressId" label="Address Id" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $addressBookApiBeta } = useNuxtApp()
+
+const formData = reactive({
+  addressId: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $addressBookApiBeta.resendVerification(formData.addressId)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>


### PR DESCRIPTION
Adds two debug pages and corresponding $addressBookApiBeta client methods for the new self-hosted wallet verification lifecycle endpoints:

- POST /v1/addressBook/recipients/{id}/verification/cancel
- POST /v1/addressBook/recipients/{id}/verification/resend

Both pages follow the existing addressBook/delete.vue pattern (single input + Make api call button, RequestInfo for success, ErrorSheet for errors). Sidenav entries added under the existing addressBook block in layouts/default.vue.