### PR TITLE
feat: send recipient lei under identity instead of metadata

### DIFF
--- a/lib/beta/addressBookApi.ts
+++ b/lib/beta/addressBookApi.ts
@@ -12,13 +12,13 @@ export interface CreateRecipientPayload {
     email: string
     bns: string
     nickname: string
-    lei?: string
   }
   identity?: {
     type: string
     firstName?: string
     lastName?: string
     businessName?: string
+    lei?: string
     individual?: {
       dateOfBirth?: string
       nationality?: string

--- a/pages/debug/addressBook/create.vue
+++ b/pages/debug/addressBook/create.vue
@@ -262,7 +262,6 @@ const makeApiCall = async () => {
       email: formData.email,
       bns: formData.bns,
       nickname: formData.nickname,
-      ...(formData.lei && { lei: formData.lei }),
     },
   }
 
@@ -283,6 +282,7 @@ const makeApiCall = async () => {
       }),
       ...(formData.identityType === 'business' && {
         businessName: formData.businessName || undefined,
+        lei: formData.lei || undefined,
       }),
     }
 


### PR DESCRIPTION
## Summary
Update the debug create-recipient form to send the LEI (Legal Entity Identifier) at a flat top-level `identity.lei` (business-only) instead of `metadata.lei`, matching the address book recipient API. LEI is set only at create.

## Details
- `lib/beta/addressBookApi.ts` — `CreateRecipientPayload`: removed `metadata.lei`; added top-level `identity.lei` (ordered above `individual`, not nested under `business`).
- `pages/debug/addressBook/create.vue` — populate `identity.lei` from the business-gated LEI field; dropped it from `metadata`.

Scope is the `pages/debug/addressBook` debug console only.
