### PR TITLE
refactor: pluralize StableFX Settlement Advance API paths

### DIFF
--- a/lib/stablefxTradesApi.ts
+++ b/lib/stablefxTradesApi.ts
@@ -141,7 +141,7 @@ const STABLEFX_QUOTES_PATH = '/v1/exchange/stablefx/quotes'
 const STABLEFX_SIGNATURES_PATH = '/v1/exchange/stablefx/signatures'
 const STABLEFX_FUND_PATH = '/v1/exchange/stablefx/fund'
 const STABLEFX_SETTLEMENT_ADVANCE_PATH =
-  '/v1/exchange/stablefx/settlementAdvance'
+  '/v1/exchange/stablefx/settlementAdvances'
 /**
  * Global error handler:
  * Intercepts all axios reponses and maps
@@ -296,7 +296,7 @@ function reserveSettlementAdvance(payload: ReserveSettlementAdvancePayload) {
  * Cancel a StableFX Settlement Advance Reservation
  */
 function cancelSettlementAdvanceReservation(reservationId: string) {
-  const url = `${STABLEFX_SETTLEMENT_ADVANCE_PATH}/reservation/${reservationId}/cancel`
+  const url = `${STABLEFX_SETTLEMENT_ADVANCE_PATH}/reservations/${reservationId}/cancel`
   return instance.post(url)
 }
 
@@ -306,7 +306,7 @@ function cancelSettlementAdvanceReservation(reservationId: string) {
 function getSettlementAdvancePresignData(
   payload: SettlementAdvancePresignPayload,
 ) {
-  const url = `${STABLEFX_SIGNATURES_PATH}/settlementAdvance/presign`
+  const url = `${STABLEFX_SIGNATURES_PATH}/settlementAdvances/presign`
   return instance.post(url, payload)
 }
 
@@ -353,14 +353,14 @@ function getSettlementAdvances(
  * Repay a StableFX Settlement Advance
  */
 function repaySettlementAdvance(payload: RepaySettlementAdvancePayload) {
-  return instance.post(`${STABLEFX_SETTLEMENT_ADVANCE_PATH}/repayment`, payload)
+  return instance.post(`${STABLEFX_SETTLEMENT_ADVANCE_PATH}/repayments`, payload)
 }
 
 /**
  * Get a StableFX Settlement Advance Repayment by ID
  */
 function getSettlementAdvanceRepayment(repaymentId: string) {
-  const url = `${STABLEFX_SETTLEMENT_ADVANCE_PATH}/repayment/${repaymentId}`
+  const url = `${STABLEFX_SETTLEMENT_ADVANCE_PATH}/repayments/${repaymentId}`
   return instance.get(url)
 }
 

--- a/lib/stablefxTradesApi.ts
+++ b/lib/stablefxTradesApi.ts
@@ -353,7 +353,10 @@ function getSettlementAdvances(
  * Repay a StableFX Settlement Advance
  */
 function repaySettlementAdvance(payload: RepaySettlementAdvancePayload) {
-  return instance.post(`${STABLEFX_SETTLEMENT_ADVANCE_PATH}/repayments`, payload)
+  return instance.post(
+    `${STABLEFX_SETTLEMENT_ADVANCE_PATH}/repayments`,
+    payload,
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

Mirrors [wallets-api#3485](https://github.com/crcl-main/wallets-api/pull/3485), which pluralizes the StableFX Settlement Advance external **collection** resources per REST convention. Updates the sample app's outbound request paths in `lib/stablefxTradesApi.ts` in lockstep.

| Before | After | Affects |
|---|---|---|
| `/settlementAdvance` | `/settlementAdvances` | list + create + `GET /{advanceId}` |
| `…/reservation/{id}/cancel` | `…/reservations/{id}/cancel` | cancel reservation |
| `/signatures/settlementAdvance/presign` | `/signatures/settlementAdvances/presign` | signature presign |
| `…/repayment` | `…/repayments` | create repayment + by-id |
| `…/credit` | unchanged | per-maker singleton |

Verb sub-paths (`reserve`, `cancel`) are unchanged. The `/debug/stablefx/settlementAdvance/...` Nuxt page routes are local frontend paths, not backend API calls, so they are left as-is.

## Test plan

- [ ] `BASE_URL=https://api-smokebox.circle.com` — exercise SA flows against smokebox

🤖 Generated with [Claude Code](https://claude.com/claude-code)