### PR TITLE
fix(deps): bump shell-quote to 1.9.0 (CVE-2026-9277)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9292,9 +9292,9 @@ shebang-regex@^3.0.0:
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.8.3:
-  version "1.8.3"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.9.0.tgz#e108b1a136586d5964edb3300016d4bedba0fe57"
+  integrity sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==
 
 side-channel-list@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary
Bumps the transitive `shell-quote` dependency from **1.8.3 -> 1.9.0** to resolve **CVE-2026-9277** (critical: arbitrary code execution via command injection from unescaped input). The patched release is 1.8.4; 1.9.0 is the current resolution within the existing `^1.8.3` range.

## Why
The downstream build pipeline runs a Trivy image scan with `fail_on_critical: true`. The production image SBOM flagged `shell-quote` CVE-2026-9277 as the only unsuppressed CRITICAL, breaking the build.

`shell-quote` is pulled in transitively via `launch-editor`. The existing `^1.8.3` range already permits the fix, so **only the resolved lockfile version changes** -- no `package.json` change.

## Verification
- `trivy fs --severity CRITICAL` on `yarn.lock` -> 0 vulnerabilities (was 1 in the production image scan).
- `yarn install --frozen-lockfile` succeeds (lockfile in sync).
- Only `shell-quote` changed; no other dependencies shifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)