### PR TITLE
feat: add MXNB to StableFX quote debug page currencies

### DIFF
--- a/pages/debug/stablefx/quote.vue
+++ b/pages/debug/stablefx/quote.vue
@@ -149,12 +149,13 @@ const loading = ref(false)
 const showError = ref(false)
 const signingLoading = ref(false)
 const signatureResult = ref('')
-const currencies = ['USDC', 'EURC', 'QCAD', 'AUDF']
+const currencies = ['USDC', 'EURC', 'QCAD', 'AUDF', 'MXNB']
 const toCurrencyMap = new Map([
-  ['USDC', ['EURC', 'QCAD', 'AUDF']],
+  ['USDC', ['EURC', 'QCAD', 'AUDF', 'MXNB']],
   ['QCAD', ['USDC']],
   ['AUDF', ['USDC']],
   ['EURC', ['USDC']],
+  ['MXNB', ['USDC']],
 ])
 
 const payload = computed(() => store.getRequestPayload)


### PR DESCRIPTION
## Summary
- Added `MXNB` to the from-currency list on the StableFX quote debug page
- Added `MXNB` as a valid to-currency option when `USDC` is selected as from-currency
- Added `MXNB -> [USDC]` mapping so USDC appears as the to-currency when MXNB is selected

## Test plan
- [ ] Navigate to `/debug/stablefx/quote`
- [ ] Verify `MXNB` appears in the "From currency" dropdown
- [ ] Select `USDC` as from-currency and confirm `MXNB` appears in the "To currency" dropdown
- [ ] Select `MXNB` as from-currency and confirm `USDC` appears in the "To currency" dropdown
- [ ] Submit a quote with MXNB and verify the API call succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)