### PR TITLE
feat: support additional currencies HKD, CNH, and SGD 

### DIFF
--- a/pages/debug/trades/flow/index.vue
+++ b/pages/debug/trades/flow/index.vue
@@ -127,12 +127,15 @@ const required = (v: string) => !!v || 'Field is required'
 const isNumber = (v: string) =>
   !v || v === '' || !isNaN(parseInt(v)) || 'Please enter valid number'
 
-const currencies = ['USDC', 'EURC', 'MXN', 'BRL']
+const currencies = ['USDC', 'EURC', 'MXN', 'BRL', 'HKD', 'CNH', 'SGD']
 const toCurrencyMap = new Map([
-  ['USDC', ['EURC', 'MXN', 'BRL']],
+  ['USDC', ['EURC', 'MXN', 'BRL', 'HKD', 'CNH', 'SGD']],
   ['EURC', ['USDC']],
   ['MXN', ['USDC']],
   ['BRL', ['USDC']],
+  ['HKD', ['USDC']],
+  ['CNH', ['USDC']],
+  ['SGD', ['USDC']],
 ])
 
 const onErrorSheetClosed = () => {

--- a/pages/debug/trades/quote.vue
+++ b/pages/debug/trades/quote.vue
@@ -78,12 +78,15 @@ const formData = reactive({
 const error = ref<any>({})
 const loading = ref(false)
 const showError = ref(false)
-const currencies = ['USDC', 'EURC', 'MXN', 'BRL']
+const currencies = ['USDC', 'EURC', 'MXN', 'BRL', 'HKD', 'CNH', 'SGD']
 const toCurrencyMap = new Map([
-  ['USDC', ['EURC', 'MXN', 'BRL']],
+  ['USDC', ['EURC', 'MXN', 'BRL', 'HKD', 'CNH', 'SGD']],
   ['EURC', ['USDC']],
   ['MXN', ['USDC']],
   ['BRL', ['USDC']],
+  ['HKD', ['USDC']],
+  ['CNH', ['USDC']],
+  ['SGD', ['USDC']],
 ])
 
 const payload = computed(() => store.getRequestPayload)

--- a/pages/debug/trades/settlements/fetch.vue
+++ b/pages/debug/trades/settlements/fetch.vue
@@ -63,6 +63,7 @@ const formData = reactive({
 const error = ref<any>({})
 const loading = ref(false)
 const showError = ref(false)
+const settlementCurrencies = ['', 'MXN', 'BRL', 'HKD', 'CNH', 'SGD']
 
 const payload = computed(() => store.getRequestPayload)
 const response = computed(() => store.getRequestResponse)

--- a/pages/debug/trades/settlements/instructions.vue
+++ b/pages/debug/trades/settlements/instructions.vue
@@ -44,7 +44,7 @@ const { $tradesApi } = useNuxtApp()
 const error = ref<any>({})
 const loading = ref(false)
 const showError = ref(false)
-const currencies = ['MXN', 'BRL']
+const currencies = ['MXN', 'BRL', 'HKD', 'CNH', 'SGD']
 const selectedCurrency = ref('MXN')
 
 const payload = computed(() => store.getRequestPayload)


### PR DESCRIPTION
## Summary
- add `HKD`, `CNH`, and `SGD` to the legacy trades quote debug screen, flow debug screen
- add `HKD`, `CNH`, and `SGD` to the legacy trades settlements fetch and instructions screens

This follows the same lightweight currency-enable pattern as [#456](https://github.com/circlefin/payments-sample-app/pull/456), but for the legacy trades screens instead of StableFX.

## Test plan
- [x] Navigate to `/debug/trades/quote` and verify `HKD`, `CNH`, and `SGD` appear in the currency options
- [x] Navigate to `/debug/trades/flow` and verify each currency can be used to complete the trade flow successfully
- [x] Verify successful local trade flow submissions for `HKD`
- [x] Verify successful local trade flow submissions for `CNH`
- [x] Verify successful local trade flow submissions for `SGD`

## Validation
Validated locally in the sample app with successful trade flow submissions for all three currencies:

<img width="1512" height="817" alt="Screenshot 2026-07-03 at 9 22 00 AM" src="https://github.com/user-attachments/assets/202f8e2c-a045-4249-b6a3-f92489ae233c" />


<img width="1510" height="813" alt="Screenshot 2026-07-03 at 8 35 29 AM" src="https://github.com/user-attachments/assets/e54bd526-e828-4eda-95e4-5f9cfb3a71a0" />


<img width="1511" height="815" alt="Screenshot 2026-07-03 at 8 35 15 AM" src="https://github.com/user-attachments/assets/712942e9-26a8-4d3b-badc-a1f6944c90b9" />
