### PR TITLE
fix: prevent stale chunk errors after deploys

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -70,6 +70,11 @@ export default defineNuxtConfig({
     },
   },
 
+  routeRules: {
+    '/**': { headers: { 'cache-control': 'no-cache' } },
+    '/_nuxt/**': { headers: { 'cache-control': 'public, max-age=31536000, immutable' } },
+  },
+
   vite: {
     define: {
       global: 'globalThis',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -72,7 +72,9 @@ export default defineNuxtConfig({
 
   routeRules: {
     '/**': { headers: { 'cache-control': 'no-cache' } },
-    '/_nuxt/**': { headers: { 'cache-control': 'public, max-age=31536000, immutable' } },
+    '/_nuxt/**': {
+      headers: { 'cache-control': 'public, max-age=31536000, immutable' },
+    },
   },
 
   vite: {


### PR DESCRIPTION
## What

Sets correct HTTP cache headers via Nuxt `routeRules`:

- HTML pages: `Cache-Control: no-cache` — browsers always fetch fresh markup after a deploy
- `/_nuxt/**` chunks: `Cache-Control: public, max-age=31536000, immutable` — safe to cache forever since filenames are content-hashed

## Why

After a production deploy, users with cached HTML referencing old chunk hashes would get a `Failed to fetch dynamically imported module` 500 error. A hard reload fixed it individually, but the correct fix is ensuring HTML is never stale.

## Test plan

- [ ] Deploy to sample environment and verify HTML response includes `Cache-Control: no-cache`
- [ ] Verify `/_nuxt/*.js` responses include `Cache-Control: public, max-age=31536000, immutable`
- [ ] Confirm no chunk-load errors after a fresh deploy with cached browser sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)