### PR TITLE
feat: support BRLA, KRW1, GBPA in StableFX debug quote

### DIFF
--- a/pages/debug/stablefx/quote.vue
+++ b/pages/debug/stablefx/quote.vue
@@ -149,13 +149,25 @@ const loading = ref(false)
 const showError = ref(false)
 const signingLoading = ref(false)
 const signatureResult = ref('')
-const currencies = ['USDC', 'EURC', 'QCAD', 'AUDF', 'MXNB']
+const currencies = [
+  'USDC',
+  'EURC',
+  'QCAD',
+  'AUDF',
+  'MXNB',
+  'BRLA',
+  'KRW1',
+  'GBPA',
+]
 const toCurrencyMap = new Map([
-  ['USDC', ['EURC', 'QCAD', 'AUDF', 'MXNB']],
+  ['USDC', ['EURC', 'QCAD', 'AUDF', 'MXNB', 'BRLA', 'KRW1', 'GBPA']],
   ['QCAD', ['USDC']],
   ['AUDF', ['USDC']],
   ['EURC', ['USDC']],
   ['MXNB', ['USDC']],
+  ['BRLA', ['USDC']],
+  ['KRW1', ['USDC']],
+  ['GBPA', ['USDC']],
 ])
 
 const payload = computed(() => store.getRequestPayload)


### PR DESCRIPTION
## Summary
Adds **BRLA**, **KRW1**, and **GBPA** (each vs USDC) to the StableFX debug quote page so they can be selected for quoting

## Detail
`pages/debug/stablefx/quote.vue`:
- Add `BRLA`/`KRW1`/`GBPA` to the `currencies` list
- Add them to USDC's allowed to-currencies and add `BRLA`/`KRW1`/`GBPA → [USDC]` entries in `toCurrencyMap`