### PR TITLE
feat: add Digital Asset Accounts (DAA) debug section

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -40,6 +40,29 @@
         <v-list-group>
           <template #activator="{ props }">
             <v-list-item v-bind="props">
+              <v-list-item-title>Digital Asset Accounts</v-list-item-title>
+            </v-list-item>
+          </template>
+
+          <v-list-item to="/debug/daa" exact>
+            <v-list-item-title class="list-items"> Overview </v-list-item-title>
+          </v-list-item>
+
+          <v-list-item
+            v-for="(item, i) in daaLinks"
+            :key="`daaLinks-${i}`"
+            :to="item.to"
+            exact
+          >
+            <v-list-item-title class="list-items">
+              {{ item.title }}
+            </v-list-item-title>
+          </v-list-item>
+        </v-list-group>
+
+        <v-list-group>
+          <template #activator="{ props }">
+            <v-list-item v-bind="props">
               <v-list-item-title>Payments APIs</v-list-item-title>
             </v-list-item>
           </template>
@@ -239,6 +262,37 @@
               </v-form>
             </v-expansion-panel-text>
           </v-expansion-panel>
+
+          <!-- Risk Signals Settings -->
+          <v-expansion-panel>
+            <v-expansion-panel-title> Risk Signals </v-expansion-panel-title>
+            <v-expansion-panel-text>
+              <v-form>
+                <v-text-field
+                  v-model="riskSignalIpAddress"
+                  label="IP Address"
+                  variant="outlined"
+                  class="mb-4"
+                />
+                <v-text-field
+                  v-model="riskSignalSessionId"
+                  label="Session ID"
+                  variant="outlined"
+                  class="mb-4"
+                />
+                <v-text-field
+                  v-model="riskSignalDeviceId"
+                  label="Device ID"
+                  variant="outlined"
+                  class="mb-4"
+                />
+                <p class="subtitle-2 font-weight-light">
+                  Risk signals for the end user initiating the request. Required
+                  when creating wire accounts.
+                </p>
+              </v-form>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
         </v-expansion-panels>
       </div>
     </v-navigation-drawer>
@@ -247,6 +301,89 @@
 
 <script setup lang="ts">
 const store = useMainStore()
+
+const daaLinks = [
+  {
+    title: 'POST /accounts',
+    to: '/debug/daa/accounts/create',
+  },
+  {
+    title: 'GET /accounts',
+    to: '/debug/daa/accounts/fetch',
+  },
+  {
+    title: 'GET /accounts/{id}',
+    to: '/debug/daa/accounts/details',
+  },
+  {
+    title: 'POST /banks/wires',
+    to: '/debug/daa/wires/create',
+  },
+  {
+    title: 'GET /banks/wires',
+    to: '/debug/daa/wires/fetch',
+  },
+  {
+    title: 'GET /banks/wires/{id}',
+    to: '/debug/daa/wires/details',
+  },
+  {
+    title: 'GET /banks/wires/{id}/instructions',
+    to: '/debug/daa/wires/instructions',
+  },
+  {
+    title: 'POST /accounts/transfers',
+    to: '/debug/daa/transfers/create',
+  },
+  {
+    title: 'GET /accounts/transfers',
+    to: '/debug/daa/transfers/fetch',
+  },
+  {
+    title: 'GET /accounts/transfers/{id}',
+    to: '/debug/daa/transfers/details',
+  },
+  {
+    title: 'GET /accounts/transactions',
+    to: '/debug/daa/transactions/fetch',
+  },
+  {
+    title: 'POST /accounts/withdrawals',
+    to: '/debug/daa/withdrawals/create',
+  },
+  {
+    title: 'GET /accounts/withdrawals',
+    to: '/debug/daa/withdrawals/fetch',
+  },
+  {
+    title: 'GET /accounts/withdrawals/{id}',
+    to: '/debug/daa/withdrawals/details',
+  },
+  {
+    title: 'POST /accounts/addresses/deposit',
+    to: '/debug/daa/addresses/deposit/create',
+  },
+  {
+    title: 'GET /accounts/addresses/deposit',
+    to: '/debug/daa/addresses/deposit/fetch',
+  },
+  {
+    title: 'POST /addresses/recipient',
+    to: '/debug/daa/addresses/recipient/create',
+  },
+  {
+    title: 'GET /addresses/recipient',
+    to: '/debug/daa/addresses/recipient/fetch',
+  },
+  {
+    title: 'DELETE /addresses/recipient/{id}',
+    to: '/debug/daa/addresses/recipient/delete',
+  },
+  {
+    title: 'GET /accounts/deposits',
+    to: '/debug/daa/deposits/fetch',
+  },
+]
 
 const coreLinks = [
   {
@@ -601,6 +738,24 @@ const walletId = computed({
 const funderWalletId = computed({
   get: () => store.getFunderWalletId,
   set: (value: string) => store.setFunderWalletId(value),
+})
+
+const riskSignalIpAddress = computed({
+  get: () => store.getRiskSignals.ipAddress,
+  set: (value: string) =>
+    store.setRiskSignals({ ...store.getRiskSignals, ipAddress: value }),
+})
+
+const riskSignalSessionId = computed({
+  get: () => store.getRiskSignals.sessionId,
+  set: (value: string) =>
+    store.setRiskSignals({ ...store.getRiskSignals, sessionId: value }),
+})
+
+const riskSignalDeviceId = computed({
+  get: () => store.getRiskSignals.deviceId,
+  set: (value: string) =>
+    store.setRiskSignals({ ...store.getRiskSignals, deviceId: value }),
 })
 </script>
 

--- a/lib/daa/accountsApi.ts
+++ b/lib/daa/accountsApi.ts
@@ -1,0 +1,68 @@
+import { daaInstance, nullIfEmpty } from './client'
+
+export interface CreateAccountPayload {
+  idempotencyKey: string
+  description: string
+  type: string
+  purpose: string
+  clientEntityId?: string
+}
+
+const ACCOUNTS_PATH = '/v1/accounts'
+
+/** Returns the shared DAA axios instance */
+function getInstance() {
+  return daaInstance
+}
+
+/**
+ * Create Account
+ */
+function createAccount(payload: CreateAccountPayload) {
+  if (!payload.clientEntityId) {
+    delete payload.clientEntityId
+  }
+  return daaInstance.post(ACCOUNTS_PATH, payload)
+}
+
+/**
+ * Get Accounts
+ */
+function getAccounts(
+  clientEntityId: string,
+  type: string,
+  purpose: string,
+  status: string,
+  from: string,
+  to: string,
+  pageBefore: string,
+  pageAfter: string,
+  pageSize: string,
+) {
+  const params = {
+    clientEntityId: nullIfEmpty(clientEntityId),
+    type: nullIfEmpty(type),
+    purpose: nullIfEmpty(purpose),
+    status: nullIfEmpty(status),
+    from: nullIfEmpty(from),
+    to: nullIfEmpty(to),
+    pageBefore: nullIfEmpty(pageBefore),
+    pageAfter: nullIfEmpty(pageAfter),
+    pageSize: nullIfEmpty(pageSize),
+  }
+  return daaInstance.get(ACCOUNTS_PATH, { params })
+}
+
+/**
+ * Get Account by id
+ */
+function getAccountById(accountId: string) {
+  return daaInstance.get(`${ACCOUNTS_PATH}/${accountId}`)
+}
+
+export default {
+  getInstance,
+  createAccount,
+  getAccounts,
+  getAccountById,
+}

--- a/lib/daa/addressesApi.ts
+++ b/lib/daa/addressesApi.ts
@@ -1,0 +1,101 @@
+import { daaInstance, nullIfEmpty } from './client'
+
+export interface CreateDepositAddressPayload {
+  idempotencyKey: string
+  currency: string
+  chain: string
+  clientEntityId?: string
+}
+
+export interface CreateRecipientAddressPayload {
+  idempotencyKey: string
+  address: string
+  addressTag?: string
+  chain: string
+  currency?: string
+  description: string
+  clientEntityId?: string
+}
+
+const DEPOSIT_PATH = '/v1/accounts/addresses/deposit'
+const RECIPIENT_PATH = '/v1/addresses/recipient'
+
+/** Returns the shared DAA axios instance */
+function getInstance() {
+  return daaInstance
+}
+
+/**
+ * Create deposit address
+ */
+function createDepositAddress(payload: CreateDepositAddressPayload) {
+  if (!payload.clientEntityId) {
+    delete payload.clientEntityId
+  }
+  return daaInstance.post(DEPOSIT_PATH, payload)
+}
+
+/**
+ * Get deposit addresses
+ */
+function getDepositAddresses(
+  clientEntityId: string,
+  chain: string,
+  currency: string,
+) {
+  const params = {
+    clientEntityId: nullIfEmpty(clientEntityId),
+    chain: nullIfEmpty(chain),
+    currency: nullIfEmpty(currency),
+  }
+  return daaInstance.get(DEPOSIT_PATH, { params })
+}
+
+/**
+ * Create recipient address
+ */
+function createRecipientAddress(payload: CreateRecipientAddressPayload) {
+  payload.currency = nullIfEmpty(payload.currency)
+  if (!payload.clientEntityId) {
+    delete payload.clientEntityId
+  }
+  return daaInstance.post(RECIPIENT_PATH, payload)
+}
+
+/**
+ * Get recipient addresses
+ */
+function getRecipientAddresses(
+  clientEntityId: string,
+  from: string,
+  to: string,
+  pageBefore: string,
+  pageAfter: string,
+  pageSize: string,
+) {
+  const params = {
+    clientEntityId: nullIfEmpty(clientEntityId),
+    from: nullIfEmpty(from),
+    to: nullIfEmpty(to),
+    pageBefore: nullIfEmpty(pageBefore),
+    pageAfter: nullIfEmpty(pageAfter),
+    pageSize: nullIfEmpty(pageSize),
+  }
+  return daaInstance.get(RECIPIENT_PATH, { params })
+}
+
+/**
+ * Delete selected recipient address
+ */
+function deleteRecipientAddress(recipientId: string) {
+  return daaInstance.delete(`${RECIPIENT_PATH}/${recipientId}`)
+}
+
+export default {
+  getInstance,
+  createDepositAddress,
+  getDepositAddresses,
+  createRecipientAddress,
+  getRecipientAddresses,
+  deleteRecipientAddress,
+}

--- a/lib/daa/client.ts
+++ b/lib/daa/client.ts
@@ -1,0 +1,43 @@
+import get from 'lodash/get'
+import axios from 'axios'
+
+import { getAPIHostname } from '../apiTarget'
+
+/**
+ * Shared axios instance for the Digital Asset Accounts (DAA) endpoints.
+ * Request/response store-capture and auth interceptors are attached once in
+ * plugins/daa/index.ts.
+ */
+export const daaInstance = axios.create({
+  baseURL: getAPIHostname(),
+})
+
+/**
+ * Global error handler:
+ * Intercepts all axios responses and maps to errorHandler object
+ */
+daaInstance.interceptors.response.use(
+  function (response) {
+    if (get(response, 'data.data')) {
+      return response.data.data
+    }
+    if (response.data !== undefined) {
+      return response.data
+    }
+    return response
+  },
+  function (error) {
+    let response = get(error, 'response')
+    if (!response) {
+      response = error.toJSON()
+    }
+    return Promise.reject(response)
+  },
+)
+
+export const nullIfEmpty = (prop: string | undefined) => {
+  if (prop === '') {
+    return undefined
+  }
+  return prop
+}

--- a/lib/daa/depositsApi.ts
+++ b/lib/daa/depositsApi.ts
@@ -1,0 +1,37 @@
+import { daaInstance, nullIfEmpty } from './client'
+
+const DEPOSITS_PATH = '/v1/accounts/deposits'
+
+/** Returns the shared DAA axios instance */
+function getInstance() {
+  return daaInstance
+}
+
+/**
+ * Get Deposits
+ */
+function getDeposits(
+  clientEntityId: string,
+  type: string,
+  from: string,
+  to: string,
+  pageBefore: string,
+  pageAfter: string,
+  pageSize: string,
+) {
+  const params = {
+    clientEntityId: nullIfEmpty(clientEntityId),
+    type: nullIfEmpty(type),
+    from: nullIfEmpty(from),
+    to: nullIfEmpty(to),
+    pageBefore: nullIfEmpty(pageBefore),
+    pageAfter: nullIfEmpty(pageAfter),
+    pageSize: nullIfEmpty(pageSize),
+  }
+  return daaInstance.get(DEPOSITS_PATH, { params })
+}
+
+export default {
+  getInstance,
+  getDeposits,
+}

--- a/lib/daa/transactionsApi.ts
+++ b/lib/daa/transactionsApi.ts
@@ -1,0 +1,41 @@
+import { daaInstance, nullIfEmpty } from './client'
+
+const TRANSACTIONS_PATH = '/v1/accounts/transactions'
+
+/** Returns the shared DAA axios instance */
+function getInstance() {
+  return daaInstance
+}
+
+/**
+ * Get Account Transactions
+ */
+function getTransactions(
+  clientEntityId: string,
+  accountId: string,
+  type: string,
+  currency: string,
+  from: string,
+  to: string,
+  pageBefore: string,
+  pageAfter: string,
+  pageSize: string,
+) {
+  const params = {
+    clientEntityId: nullIfEmpty(clientEntityId),
+    accountId: nullIfEmpty(accountId),
+    type: nullIfEmpty(type),
+    currency: nullIfEmpty(currency),
+    from: nullIfEmpty(from),
+    to: nullIfEmpty(to),
+    pageBefore: nullIfEmpty(pageBefore),
+    pageAfter: nullIfEmpty(pageAfter),
+    pageSize: nullIfEmpty(pageSize),
+  }
+  return daaInstance.get(TRANSACTIONS_PATH, { params })
+}
+
+export default {
+  getInstance,
+  getTransactions,
+}

--- a/lib/daa/transfersApi.ts
+++ b/lib/daa/transfersApi.ts
@@ -1,0 +1,81 @@
+import { daaInstance, nullIfEmpty } from './client'
+
+export interface BlockchainDestination {
+  type: string
+  addressId: string
+}
+
+export interface AccountDestination {
+  type: string
+  id: string
+}
+
+export interface Source {
+  type: string
+  id: string
+}
+
+export interface Amount {
+  amount: string
+  currency: string
+}
+
+export interface CreateTransferPayload {
+  idempotencyKey: string
+  destination: BlockchainDestination | AccountDestination
+  amount: Amount
+  source?: Source
+}
+
+const TRANSFERS_PATH = '/v1/accounts/transfers'
+
+/** Returns the shared DAA axios instance */
+function getInstance() {
+  return daaInstance
+}
+
+/**
+ * Create Transfer
+ */
+function createTransfer(payload: CreateTransferPayload) {
+  if (!payload.source?.id) {
+    delete payload.source
+  }
+  return daaInstance.post(TRANSFERS_PATH, payload)
+}
+
+/**
+ * Get transfers
+ */
+function getTransfers(
+  clientEntityId: string,
+  from: string,
+  to: string,
+  pageBefore: string,
+  pageAfter: string,
+  pageSize: string,
+) {
+  const params = {
+    clientEntityId: nullIfEmpty(clientEntityId),
+    from: nullIfEmpty(from),
+    to: nullIfEmpty(to),
+    pageBefore: nullIfEmpty(pageBefore),
+    pageAfter: nullIfEmpty(pageAfter),
+    pageSize: nullIfEmpty(pageSize),
+  }
+  return daaInstance.get(TRANSFERS_PATH, { params })
+}
+
+/**
+ * Get Transfer by id
+ */
+function getTransferById(transferId: string) {
+  return daaInstance.get(`${TRANSFERS_PATH}/${transferId}`)
+}
+
+export default {
+  getInstance,
+  createTransfer,
+  getTransfers,
+  getTransferById,
+}

--- a/lib/daa/wiresApi.ts
+++ b/lib/daa/wiresApi.ts
@@ -1,0 +1,111 @@
+import { daaInstance, nullIfEmpty } from './client'
+
+export interface RiskSignals {
+  ipAddress: string
+  sessionId: string
+  deviceId: string
+}
+
+export interface CreateWireAccountPayload {
+  idempotencyKey: string
+  clientEntityId?: string
+  beneficiaryName: string
+  accountNumber?: string
+  routingNumber?: string
+  iban?: string
+  ffcMemo?: string
+  billingDetails: {
+    name: string
+    city: string
+    country: string
+    line1: string
+    line2: string
+    district: string
+    postalCode: string
+  }
+  bankAddress: {
+    bankName?: string
+    city?: string
+    country: string
+    line1?: string
+    line2?: string
+    district?: string
+    postalCode?: string
+  }
+  intermediaryBank?: {
+    identifier?: string
+    type?: string
+    countryCode?: string
+  }
+  riskSignals: RiskSignals
+}
+
+const WIRES_PATH = '/v1/banks/wires'
+
+/** Returns the shared DAA axios instance */
+function getInstance() {
+  return daaInstance
+}
+
+/**
+ * Create wire bank account
+ */
+function createWireAccount(payload: CreateWireAccountPayload) {
+  payload.accountNumber = nullIfEmpty(payload.accountNumber)
+  payload.routingNumber = nullIfEmpty(payload.routingNumber)
+  payload.iban = nullIfEmpty(payload.iban)
+  payload.bankAddress.bankName = nullIfEmpty(payload.bankAddress.bankName)
+  payload.bankAddress.city = nullIfEmpty(payload.bankAddress.city)
+  payload.bankAddress.line1 = nullIfEmpty(payload.bankAddress.line1)
+  payload.bankAddress.line2 = nullIfEmpty(payload.bankAddress.line2)
+  payload.bankAddress.district = nullIfEmpty(payload.bankAddress.district)
+  payload.bankAddress.postalCode = nullIfEmpty(payload.bankAddress.postalCode)
+  if (!payload.clientEntityId) {
+    delete payload.clientEntityId
+  }
+  return daaInstance.post(WIRES_PATH, payload)
+}
+
+/**
+ * Get wire bank accounts
+ */
+function getWireAccounts(clientEntityId?: string) {
+  const params = {
+    clientEntityId: clientEntityId || undefined,
+  }
+  return daaInstance.get(WIRES_PATH, { params })
+}
+
+/**
+ * Get wire bank account by id
+ */
+function getWireAccountById(bankId: string) {
+  return daaInstance.get(`${WIRES_PATH}/${bankId}`)
+}
+
+/**
+ * Get wire bank account instructions
+ *
+ * Digital Asset Accounts must target an explicit wallet, so `walletId` is
+ * required (the master wallet does not expose wire instructions).
+ */
+function getWireAccountInstructions(
+  bankId: string,
+  currency: string,
+  walletId: string,
+) {
+  return daaInstance.get(`${WIRES_PATH}/${bankId}/instructions`, {
+    params: {
+      currency: nullIfEmpty(currency),
+      walletId: nullIfEmpty(walletId),
+    },
+  })
+}
+
+export default {
+  getInstance,
+  createWireAccount,
+  getWireAccounts,
+  getWireAccountById,
+  getWireAccountInstructions,
+}

--- a/lib/daa/wiresTestData.ts
+++ b/lib/daa/wiresTestData.ts
@@ -1,0 +1,58 @@
+import { exampleBankAccounts } from '@/lib/businessAccount/bankAccountsTestData'
+import type { RiskSignals } from '@/lib/daa/wiresApi'
+
+// Sample end-user risk signals used to prefill the Settings > Risk Signals
+// values alongside the wire account form.
+const sampleRiskSignals: RiskSignals = {
+  ipAddress: '1.2.3.4',
+  sessionId: '2c6d8d63-82e2-42a9-9baa-efb8251cfdd5',
+  deviceId: '2c6d8d63-82e2-42a9-9baa-efb8251cfdd5',
+}
+
+const usAccount = {
+  title: 'US Bank Account',
+  formData: {
+    clientEntityId: '9cdec2c0-1694-3e34-a457-da9fe5401e8e',
+    beneficiaryName: 'Leon Callen',
+    accountNumber: '111234555',
+    routingNumber: '111000614',
+    iban: '',
+    ffcMemo: '',
+    billingDetails: {
+      name: 'Leon Callen',
+      city: 'Boston',
+      country: 'US',
+      line1: '100 Money Street',
+      line2: 'Suite 1',
+      district: 'MA',
+      postalCode: '01234',
+    },
+    bankAddress: {
+      bankName: 'Wells Fargo Bank',
+      city: 'San Francisco',
+      country: 'US',
+      line1: '333 Market Street',
+      line2: '',
+      district: 'CA',
+      postalCode: '94105',
+    },
+    intermediaryBank: {
+      identifier: '',
+      type: '',
+      countryCode: '',
+    },
+  },
+  riskSignals: sampleRiskSignals,
+}
+
+// Reuse the non-US examples, adding an (empty) clientEntityId so the DAA form
+// resets cleanly when switching between prefills.
+const otherAccounts = exampleBankAccounts
+  .filter((account) => account.title !== 'US Bank Account')
+  .map((account) => ({
+    title: account.title,
+    formData: { clientEntityId: '', ...account.formData },
+    riskSignals: sampleRiskSignals,
+  }))
+
+export const exampleDaaWireAccounts = [usAccount, ...otherAccounts]

--- a/lib/daa/withdrawalsApi.ts
+++ b/lib/daa/withdrawalsApi.ts
@@ -1,0 +1,72 @@
+import { daaInstance, nullIfEmpty } from './client'
+
+export interface CreateWithdrawalPayload {
+  idempotencyKey: string
+  source: {
+    id: string
+    type: string
+  }
+  destination: {
+    id: string
+    type: string
+  }
+  amount: {
+    amount: string
+    currency: string
+  }
+  toAmount?: {
+    currency: string
+  }
+}
+
+const WITHDRAWALS_PATH = '/v1/accounts/withdrawals'
+
+/** Returns the shared DAA axios instance */
+function getInstance() {
+  return daaInstance
+}
+
+/**
+ * Create Withdrawal
+ */
+function createWithdrawal(payload: CreateWithdrawalPayload) {
+  return daaInstance.post(WITHDRAWALS_PATH, payload)
+}
+
+/**
+ * Get Withdrawals
+ */
+function getWithdrawals(
+  clientEntityId: string,
+  status: string,
+  from: string,
+  to: string,
+  pageBefore: string,
+  pageAfter: string,
+  pageSize: string,
+) {
+  const params = {
+    clientEntityId: nullIfEmpty(clientEntityId),
+    status: nullIfEmpty(status),
+    from: nullIfEmpty(from),
+    to: nullIfEmpty(to),
+    pageBefore: nullIfEmpty(pageBefore),
+    pageAfter: nullIfEmpty(pageAfter),
+    pageSize: nullIfEmpty(pageSize),
+  }
+  return daaInstance.get(WITHDRAWALS_PATH, { params })
+}
+
+/**
+ * Get Withdrawal by id
+ */
+function getWithdrawalById(withdrawalId: string) {
+  return daaInstance.get(`${WITHDRAWALS_PATH}/${withdrawalId}`)
+}
+
+export default {
+  getInstance,
+  createWithdrawal,
+  getWithdrawals,
+  getWithdrawalById,
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -53,6 +53,7 @@ export default defineNuxtConfig({
     '~/plugins/businessAccount/depositsApi.ts',
     '~/plugins/businessAccount/payoutsApi.ts',
     '~/plugins/businessAccount/transfersApi.ts',
+    '~/plugins/daa/index.ts',
     '~/plugins/cryptoPaymentMetadataApi.ts',
     '~/plugins/cryptoPaymentsApi.ts',
     '~/plugins/beta/addressBookApi.ts',

--- a/pages/debug/daa/accounts/create.vue
+++ b/pages/debug/daa/accounts/create.vue
@@ -1,0 +1,100 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="formData.description"
+            label="Description"
+            hint="Human-readable account label"
+          />
+
+          <v-select v-model="formData.type" :items="types" label="Type" />
+
+          <v-select
+            v-model="formData.purpose"
+            :items="purposes"
+            label="Purpose"
+          />
+
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id (optional)"
+            hint="Sub-entity identifier; omit if the caller owns the account"
+          />
+
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { v4 as uuidv4 } from 'uuid'
+import type { CreateAccountPayload } from '@/lib/daa/accountsApi'
+
+const store = useMainStore()
+const { $daaAccountsApi } = useNuxtApp()
+
+const formData = reactive({
+  description: '',
+  type: 'first_party',
+  purpose: 'custody',
+  clientEntityId: '',
+})
+
+const types = ['first_party', 'third_party']
+const purposes = ['custody']
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  const payloadData: CreateAccountPayload = {
+    idempotencyKey: uuidv4(),
+    description: formData.description,
+    type: formData.type,
+    purpose: formData.purpose,
+    clientEntityId: formData.clientEntityId,
+  }
+  try {
+    await $daaAccountsApi.createAccount(payloadData)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/accounts/details.vue
+++ b/pages/debug/daa/accounts/details.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.id" label="Account Id" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaAccountsApi } = useNuxtApp()
+
+const formData = reactive({
+  id: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaAccountsApi.getAccountById(formData.id)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/accounts/fetch.vue
+++ b/pages/debug/daa/accounts/fetch.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <header>Optional filter params:</header>
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id"
+          />
+          <v-text-field v-model="formData.type" label="Type" />
+          <v-text-field v-model="formData.purpose" label="Purpose" />
+          <v-text-field v-model="formData.status" label="Status" />
+          <v-text-field v-model="formData.from" label="From" />
+          <v-text-field v-model="formData.to" label="To" />
+          <v-text-field v-model="formData.pageSize" label="PageSize" />
+          <v-text-field v-model="formData.pageBefore" label="PageBefore" />
+          <v-text-field v-model="formData.pageAfter" label="PageAfter" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaAccountsApi } = useNuxtApp()
+
+const formData = reactive({
+  clientEntityId: '',
+  type: '',
+  purpose: '',
+  status: '',
+  from: '',
+  to: '',
+  pageSize: '',
+  pageBefore: '',
+  pageAfter: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaAccountsApi.getAccounts(
+      formData.clientEntityId,
+      formData.type,
+      formData.purpose,
+      formData.status,
+      formData.from,
+      formData.to,
+      formData.pageBefore,
+      formData.pageAfter,
+      formData.pageSize,
+    )
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/addresses/deposit/create.vue
+++ b/pages/debug/daa/addresses/deposit/create.vue
@@ -1,0 +1,91 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id (optional)"
+          />
+
+          <v-select
+            v-model="formData.currency"
+            :items="currencyTypes"
+            label="Currency"
+          />
+
+          <ChainSelect v-model="formData.chain" label="Chain" />
+
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { v4 as uuidv4 } from 'uuid'
+import type { CreateDepositAddressPayload } from '@/lib/daa/addressesApi'
+
+const store = useMainStore()
+const { $daaAddressesApi } = useNuxtApp()
+
+const formData = reactive({
+  clientEntityId: '',
+  currency: '',
+  chain: '',
+})
+
+const currencyTypes = ['USD']
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  const { clientEntityId, currency, chain } = formData
+  const payloadData: CreateDepositAddressPayload = {
+    idempotencyKey: uuidv4(),
+    currency,
+    chain,
+    clientEntityId,
+  }
+  try {
+    await $daaAddressesApi.createDepositAddress(payloadData)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/addresses/deposit/fetch.vue
+++ b/pages/debug/daa/addresses/deposit/fetch.vue
@@ -1,0 +1,78 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <header>Optional filter params:</header>
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id"
+          />
+          <ChainSelect v-model="formData.chain" label="Chain" />
+          <v-text-field v-model="formData.currency" label="Currency" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaAddressesApi } = useNuxtApp()
+
+const formData = reactive({
+  clientEntityId: '',
+  chain: '',
+  currency: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaAddressesApi.getDepositAddresses(
+      formData.clientEntityId,
+      formData.chain,
+      formData.currency,
+    )
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/addresses/recipient/create.vue
+++ b/pages/debug/daa/addresses/recipient/create.vue
@@ -1,0 +1,113 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id (optional)"
+          />
+
+          <ChainSelect v-model="formData.chain" label="Chain" />
+
+          <v-text-field v-model="formData.address" label="Recipient address" />
+
+          <v-text-field v-model="formData.currency" label="Currency" />
+
+          <v-text-field
+            v-if="hasAddressTagSupport(formData.chain)"
+            v-model="formData.addressTag"
+            label="Address Tag"
+            hint="The secondary identifier for a blockchain address which can be text, id, or hash format."
+          />
+          <v-text-field v-model="formData.description" label="Description" />
+
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { v4 as uuidv4 } from 'uuid'
+import type { CreateRecipientAddressPayload } from '@/lib/daa/addressesApi'
+import chains from '@/lib/chains.json'
+
+const store = useMainStore()
+const { $daaAddressesApi } = useNuxtApp()
+
+const formData = reactive({
+  clientEntityId: '',
+  address: '',
+  chain: '',
+  currency: '',
+  description: '',
+  addressTag: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const hasAddressTagSupport = (chain: string) => {
+  return chains.find((_chain) => {
+    return _chain.value === chain && _chain.addressTagSupport
+  })
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  const { clientEntityId, address, chain, currency, description, addressTag } =
+    formData
+  const payloadData: CreateRecipientAddressPayload = {
+    idempotencyKey: uuidv4(),
+    address,
+    chain,
+    currency,
+    description,
+    clientEntityId,
+  }
+
+  if (hasAddressTagSupport(chain)) {
+    payloadData.addressTag = addressTag
+  }
+  try {
+    await $daaAddressesApi.createRecipientAddress(payloadData)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/addresses/recipient/delete.vue
+++ b/pages/debug/daa/addresses/recipient/delete.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.recipientId" label="Recipient Id" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaAddressesApi } = useNuxtApp()
+
+const formData = reactive({
+  recipientId: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaAddressesApi.deleteRecipientAddress(formData.recipientId)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/addresses/recipient/fetch.vue
+++ b/pages/debug/daa/addresses/recipient/fetch.vue
@@ -1,0 +1,87 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <header>Optional filter params:</header>
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id"
+          />
+          <v-text-field v-model="formData.from" label="From" />
+          <v-text-field v-model="formData.to" label="To" />
+          <v-text-field v-model="formData.pageSize" label="PageSize" />
+          <v-text-field v-model="formData.pageBefore" label="PageBefore" />
+          <v-text-field v-model="formData.pageAfter" label="PageAfter" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaAddressesApi } = useNuxtApp()
+
+const formData = reactive({
+  clientEntityId: '',
+  from: '',
+  to: '',
+  pageSize: '',
+  pageBefore: '',
+  pageAfter: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaAddressesApi.getRecipientAddresses(
+      formData.clientEntityId,
+      formData.from,
+      formData.to,
+      formData.pageBefore,
+      formData.pageAfter,
+      formData.pageSize,
+    )
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/deposits/fetch.vue
+++ b/pages/debug/daa/deposits/fetch.vue
@@ -1,0 +1,89 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <header>Optional filter params:</header>
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id"
+          />
+          <v-text-field v-model="formData.type" label="Type" />
+          <v-text-field v-model="formData.from" label="From" />
+          <v-text-field v-model="formData.to" label="To" />
+          <v-text-field v-model="formData.pageSize" label="PageSize" />
+          <v-text-field v-model="formData.pageBefore" label="PageBefore" />
+          <v-text-field v-model="formData.pageAfter" label="PageAfter" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaDepositsApi } = useNuxtApp()
+
+const formData = reactive({
+  clientEntityId: '',
+  type: '',
+  from: '',
+  to: '',
+  pageSize: '',
+  pageBefore: '',
+  pageAfter: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaDepositsApi.getDeposits(
+      formData.clientEntityId,
+      formData.type,
+      formData.from,
+      formData.to,
+      formData.pageBefore,
+      formData.pageAfter,
+      formData.pageSize,
+    )
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/index.vue
+++ b/pages/debug/daa/index.vue
@@ -1,0 +1,160 @@
+<template>
+  <v-container>
+    <v-col>
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h1 class="headline">Digital Asset Accounts (DAA)</h1>
+
+        <p class="mt-6">
+          Make API calls against the Digital Asset Accounts endpoints
+          (<code>/v1/accounts</code>, <code>/v1/banks</code>,
+          <code>/v1/addresses</code>). Use the optional
+          <strong>Client Entity Id</strong> filter (and Risk Signals in Settings
+          for wire accounts) for 3rd-party flows.
+        </p>
+      </v-card>
+
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h2 class="title">Account endpoints</h2>
+        <span class="caption">Requires: api key</span>
+        <br /><br />
+        <p>Api endpoints to create and retrieve accounts and subaccounts.</p>
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/daa/accounts/create">Create account</a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/accounts/fetch">Get all accounts</a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/accounts/details">Get account by id</a>
+        </p>
+      </v-card>
+
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h2 class="title">Wire endpoints</h2>
+        <span class="caption">Requires: api key, risk signals</span>
+        <br /><br />
+        <p>Api endpoints to manage wire bank accounts.</p>
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/daa/wires/create">Create wire account</a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/wires/fetch">Get all wire accounts</a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/wires/details">Get wire account by id</a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/wires/instructions">
+            Get wire instructions for id
+          </a>
+        </p>
+      </v-card>
+
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h2 class="title">Transfer endpoints</h2>
+        <span class="caption">Requires: api key</span>
+        <br /><br />
+        <p>Api endpoints to manage transfers.</p>
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/daa/transfers/create">Create transfer</a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/transfers/fetch">Get all transfers</a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/transfers/details">Get transfer by id</a>
+        </p>
+      </v-card>
+
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h2 class="title">Transaction endpoints</h2>
+        <span class="caption">Requires: api key</span>
+        <br /><br />
+        <p>Unified view of transaction activity across account types.</p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/transactions/fetch">Get all transactions</a>
+        </p>
+      </v-card>
+
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h2 class="title">Withdrawal endpoints</h2>
+        <span class="caption">Requires: api key</span>
+        <br /><br />
+        <p>Api endpoints to manage bank withdrawals.</p>
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/daa/withdrawals/create">Create withdrawal</a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/withdrawals/fetch">Get all withdrawals</a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/withdrawals/details">Get withdrawal by id</a>
+        </p>
+      </v-card>
+
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h2 class="title">Address endpoints</h2>
+        <span class="caption">Requires: api key</span>
+        <br /><br />
+        <p>Api endpoints to manage blockchain addresses.</p>
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/daa/addresses/deposit/create">
+            Create deposit address
+          </a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/addresses/deposit/fetch">
+            Get all deposit addresses
+          </a>
+        </p>
+        <p>
+          <v-chip small color="primary warning">POST</v-chip>
+          <a href="/debug/daa/addresses/recipient/create">
+            Create recipient address
+          </a>
+        </p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/addresses/recipient/fetch">
+            Get all recipient addresses
+          </a>
+        </p>
+        <p>
+          <v-chip small color="primary accent">DELETE</v-chip>
+          <a href="/debug/daa/addresses/recipient/delete">
+            Delete selected recipient address
+          </a>
+        </p>
+      </v-card>
+
+      <v-card class="body-1 px-6 py-8 mb-4" max-width="800" outlined>
+        <h2 class="title">Deposit endpoints</h2>
+        <span class="caption">Requires: api key</span>
+        <br /><br />
+        <p>Api endpoints to manage deposits.</p>
+        <p>
+          <v-chip small color="primary">GET</v-chip>
+          <a href="/debug/daa/deposits/fetch">Get all deposits</a>
+        </p>
+      </v-card>
+    </v-col>
+  </v-container>
+</template>
+
+<script setup lang="ts"></script>

--- a/pages/debug/daa/transactions/fetch.vue
+++ b/pages/debug/daa/transactions/fetch.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <header>Optional filter params:</header>
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id"
+          />
+          <v-text-field v-model="formData.accountId" label="Account Id" />
+          <v-text-field v-model="formData.type" label="Type" />
+          <v-text-field v-model="formData.currency" label="Currency" />
+          <v-text-field v-model="formData.from" label="From" />
+          <v-text-field v-model="formData.to" label="To" />
+          <v-text-field v-model="formData.pageSize" label="PageSize" />
+          <v-text-field v-model="formData.pageBefore" label="PageBefore" />
+          <v-text-field v-model="formData.pageAfter" label="PageAfter" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaTransactionsApi } = useNuxtApp()
+
+const formData = reactive({
+  clientEntityId: '',
+  accountId: '',
+  type: '',
+  currency: '',
+  from: '',
+  to: '',
+  pageSize: '',
+  pageBefore: '',
+  pageAfter: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaTransactionsApi.getTransactions(
+      formData.clientEntityId,
+      formData.accountId,
+      formData.type,
+      formData.currency,
+      formData.from,
+      formData.to,
+      formData.pageBefore,
+      formData.pageAfter,
+      formData.pageSize,
+    )
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/transfers/create.vue
+++ b/pages/debug/daa/transfers/create.vue
@@ -1,0 +1,113 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.amount" label="Amount" />
+
+          <v-select
+            v-model="formData.destinationType"
+            :items="destinationTypes"
+            label="Destination Type"
+          />
+
+          <v-text-field
+            v-model="formData.destinationId"
+            :label="
+              formData.destinationType === 'account'
+                ? 'Destination Account ID'
+                : 'Address ID'
+            "
+          />
+
+          <v-text-field
+            v-model="formData.sourceId"
+            label="Source Account ID (optional)"
+          />
+
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { v4 as uuidv4 } from 'uuid'
+import type { CreateTransferPayload } from '@/lib/daa/transfersApi'
+
+const store = useMainStore()
+const { $daaTransfersApi } = useNuxtApp()
+
+const formData = reactive({
+  amount: '',
+  destinationType: 'verified_blockchain',
+  destinationId: '',
+  sourceId: '',
+})
+
+const destinationTypes = ['verified_blockchain', 'account']
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+
+  const amountDetail = {
+    amount: formData.amount,
+    currency: 'USD',
+  }
+  const destinationDetail =
+    formData.destinationType === 'account'
+      ? { type: 'account', id: formData.destinationId }
+      : { type: 'verified_blockchain', addressId: formData.destinationId }
+
+  const payloadData: CreateTransferPayload = {
+    idempotencyKey: uuidv4(),
+    amount: amountDetail,
+    destination: destinationDetail,
+    ...(formData.sourceId && {
+      source: { type: 'account', id: formData.sourceId },
+    }),
+  }
+
+  try {
+    await $daaTransfersApi.createTransfer(payloadData)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/transfers/details.vue
+++ b/pages/debug/daa/transfers/details.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.id" label="Transfer Id" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaTransfersApi } = useNuxtApp()
+
+const formData = reactive({
+  id: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaTransfersApi.getTransferById(formData.id)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/transfers/fetch.vue
+++ b/pages/debug/daa/transfers/fetch.vue
@@ -1,0 +1,86 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <header>Optional filter params:</header>
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id"
+          />
+          <v-text-field v-model="formData.from" label="From" />
+          <v-text-field v-model="formData.to" label="To" />
+          <v-text-field v-model="formData.pageSize" label="PageSize" />
+          <v-text-field v-model="formData.pageBefore" label="PageBefore" />
+          <v-text-field v-model="formData.pageAfter" label="PageAfter" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaTransfersApi } = useNuxtApp()
+
+const formData = reactive({
+  clientEntityId: '',
+  from: '',
+  to: '',
+  pageSize: '',
+  pageBefore: '',
+  pageAfter: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaTransfersApi.getTransfers(
+      formData.clientEntityId,
+      formData.from,
+      formData.to,
+      formData.pageBefore,
+      formData.pageAfter,
+      formData.pageSize,
+    )
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/wires/create.vue
+++ b/pages/debug/daa/wires/create.vue
@@ -1,0 +1,303 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-menu>
+          <template #activator="{ props }">
+            <div class="d-flex flex-row-reverse">
+              <v-btn
+                v-if="isSandbox"
+                size="small"
+                color="blue-grey-lighten-1"
+                dark
+                v-bind="props"
+              >
+                Prefill form
+              </v-btn>
+            </div>
+          </template>
+          <v-list>
+            <v-list-item
+              v-for="(item, index) in prefillItems"
+              :key="index"
+              @click="prefillForm(index)"
+            >
+              <v-list-item-title>{{ item.title }}</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+
+        <v-form>
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id"
+            hint="Required for 3rd-party (DAA) flows"
+          />
+
+          <v-text-field
+            v-model="formData.beneficiaryName"
+            label="Beneficiary Name"
+            hint="Full name of the bank account holder"
+          />
+
+          <v-text-field
+            v-model="formData.accountNumber"
+            label="Account Number"
+          />
+
+          <v-text-field
+            v-model="formData.routingNumber"
+            label="Routing Number"
+            hint="RTN/BIC/Swift code of the bank associated with the account. Required for US accounts"
+          />
+
+          <v-text-field
+            v-model="formData.iban"
+            label="IBAN"
+            hint="International Bank Account Number (IBAN) that identifies the account. Required for accounts outside of the US"
+          />
+
+          <v-text-field
+            v-model="formData.ffcMemo"
+            label="FFC Memo"
+            hint="FFC Memo"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.name"
+            label="Billing Name"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.line1"
+            label="Billing Address Line 1"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.line2"
+            label="Billing Address Line 2"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.postalCode"
+            label="Billing Postalcode"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.city"
+            label="Billing City"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.district"
+            label="Billing District"
+            hint="State / County / Province / Region portion of the address. US and Canada use the two-letter code for the subdivision"
+          />
+
+          <v-text-field
+            v-model="formData.billingDetails.country"
+            label="Billing Country Code"
+          />
+
+          <v-text-field
+            v-model="formData.bankAddress.bankName"
+            label="Bank Name"
+          />
+
+          <v-text-field
+            v-model="formData.bankAddress.line1"
+            label="Bank Address Line 1"
+          />
+
+          <v-text-field
+            v-model="formData.bankAddress.line2"
+            label="Bank Address Line 2"
+          />
+
+          <v-text-field
+            v-model="formData.bankAddress.postalCode"
+            label="Bank Postalcode"
+          />
+
+          <v-text-field
+            v-model="formData.bankAddress.city"
+            label="Bank Address City"
+          />
+
+          <v-text-field
+            v-model="formData.bankAddress.district"
+            label="Bank Address District"
+            hint="State / County / Province / Region portion of the address. US and Canada use the two-letter code for the subdivision"
+          />
+
+          <v-text-field
+            v-model="formData.bankAddress.country"
+            label="Bank Address Country Code"
+          />
+
+          <v-text-field
+            v-model="formData.intermediaryBank.identifier"
+            label="Intermediary Bank Identifier"
+          />
+
+          <v-text-field
+            v-model="formData.intermediaryBank.type"
+            label="Intermediary Bank Identitifer Type"
+            hint="ABA for US domestic accounts, BIC for international"
+          />
+
+          <v-text-field
+            v-model="formData.intermediaryBank.countryCode"
+            label="Intermediary Bank Country Code"
+          />
+          <v-btn
+            variant="flat"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { v4 as uuidv4 } from 'uuid'
+import { getLive } from '@/lib/apiTarget'
+import { exampleDaaWireAccounts } from '@/lib/daa/wiresTestData'
+import type { CreateWireAccountPayload } from '@/lib/daa/wiresApi'
+
+const store = useMainStore()
+const { $daaWiresApi } = useNuxtApp()
+
+// data
+const formData = reactive({
+  clientEntityId: '',
+  beneficiaryName: '',
+  accountNumber: '',
+  routingNumber: '',
+  iban: '',
+  ffcMemo: '',
+  billingDetails: {
+    name: '',
+    city: '',
+    country: '',
+    line1: '',
+    line2: '',
+    district: '',
+    postalCode: '',
+  },
+  bankAddress: {
+    bankName: '',
+    city: '',
+    country: '',
+    line1: '',
+    line2: '',
+    district: '',
+    postalCode: '',
+  },
+  intermediaryBank: {
+    identifier: '',
+    type: '',
+    countryCode: '',
+  },
+})
+
+const prefillItems = exampleDaaWireAccounts
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const isSandbox = !getLive()
+
+// computed
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+// methods
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const prefillForm = (index: number) => {
+  Object.assign(formData, prefillItems[index].formData)
+  store.setRiskSignals({ ...prefillItems[index].riskSignals })
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  const {
+    clientEntityId,
+    beneficiaryName,
+    accountNumber,
+    routingNumber,
+    iban,
+    ffcMemo,
+    ...data
+  } = formData
+  const { billingDetails, bankAddress, intermediaryBank } = data
+
+  const payload: CreateWireAccountPayload = {
+    idempotencyKey: uuidv4(),
+    clientEntityId,
+    beneficiaryName,
+    accountNumber,
+    routingNumber,
+    iban,
+    ffcMemo,
+    billingDetails: {
+      name: billingDetails.name,
+      line1: billingDetails.line1,
+      line2: billingDetails.line2,
+      city: billingDetails.city,
+      district: billingDetails.district,
+      country: billingDetails.country,
+      postalCode: billingDetails.postalCode,
+    },
+    bankAddress: {
+      bankName: bankAddress.bankName,
+      line1: bankAddress.line1,
+      line2: bankAddress.line2,
+      city: bankAddress.city,
+      district: bankAddress.district,
+      country: bankAddress.country,
+      postalCode: bankAddress.postalCode,
+    },
+    riskSignals: { ...store.getRiskSignals },
+  }
+
+  if (intermediaryBank.identifier.length > 0) {
+    payload.intermediaryBank = {
+      identifier: intermediaryBank.identifier,
+      type: intermediaryBank.type,
+      countryCode: intermediaryBank.countryCode,
+    }
+  }
+
+  try {
+    await $daaWiresApi.createWireAccount(payload)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/wires/details.vue
+++ b/pages/debug/daa/wires/details.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.id" label="Wire Account Id" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaWiresApi } = useNuxtApp()
+
+const formData = reactive({
+  id: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaWiresApi.getWireAccountById(formData.id)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/wires/fetch.vue
+++ b/pages/debug/daa/wires/fetch.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="clientEntityId"
+            label="Client Entity Id (optional)"
+          />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaWiresApi } = useNuxtApp()
+
+const clientEntityId = ref('')
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaWiresApi.getWireAccounts(clientEntityId.value || undefined)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/wires/instructions.vue
+++ b/pages/debug/daa/wires/instructions.vue
@@ -1,0 +1,81 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.id" label="Wire Account Id" />
+          <v-text-field
+            v-model="formData.walletId"
+            label="Wallet Id"
+            hint="Required for DAA. The master wallet does not expose wire instructions."
+          />
+          <v-text-field
+            v-model="formData.currency"
+            label="Currency (Optional)"
+          />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaWiresApi } = useNuxtApp()
+
+const formData = reactive({
+  id: '',
+  walletId: '',
+  currency: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaWiresApi.getWireAccountInstructions(
+      formData.id,
+      formData.currency,
+      formData.walletId,
+    )
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/withdrawals/create.vue
+++ b/pages/debug/daa/withdrawals/create.vue
@@ -1,0 +1,123 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field
+            v-model="formData.sourceId"
+            label="Source Account Id"
+            hint="The source account for the withdrawal (type: account)"
+          />
+
+          <v-text-field v-model="formData.amount" label="Amount" />
+
+          <v-select
+            v-model="formData.currency"
+            :items="currencyTypes"
+            label="Currency"
+          />
+
+          <v-text-field
+            v-model="formData.toCurrency"
+            label="To Currency (Optional)"
+          />
+
+          <v-text-field
+            v-model="formData.destination"
+            label="Bank Account Id"
+          />
+
+          <v-select
+            v-model="formData.destinationType"
+            :items="destinationTypes"
+            label="Destination Type"
+          />
+
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { v4 as uuidv4 } from 'uuid'
+import type { CreateWithdrawalPayload } from '@/lib/daa/withdrawalsApi'
+
+const store = useMainStore()
+const { $daaWithdrawalsApi } = useNuxtApp()
+
+const formData = reactive({
+  sourceId: '',
+  amount: '0.00',
+  destination: '',
+  destinationType: 'wire',
+  currency: 'USD',
+  toCurrency: '',
+})
+
+const currencyTypes = ['USD', 'EUR']
+const destinationTypes = ['wire', 'ach']
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  const payloadData: CreateWithdrawalPayload = {
+    idempotencyKey: uuidv4(),
+    source: {
+      id: formData.sourceId,
+      type: 'account',
+    },
+    destination: {
+      id: formData.destination,
+      type: formData.destinationType,
+    },
+    amount: {
+      amount: formData.amount,
+      currency: formData.currency,
+    },
+    ...(formData.toCurrency && {
+      toAmount: { currency: formData.toCurrency },
+    }),
+  }
+  try {
+    await $daaWithdrawalsApi.createWithdrawal(payloadData)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/withdrawals/details.vue
+++ b/pages/debug/daa/withdrawals/details.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <v-text-field v-model="formData.id" label="Withdrawal Id" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaWithdrawalsApi } = useNuxtApp()
+
+const formData = reactive({
+  id: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaWithdrawalsApi.getWithdrawalById(formData.id)
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/pages/debug/daa/withdrawals/fetch.vue
+++ b/pages/debug/daa/withdrawals/fetch.vue
@@ -1,0 +1,90 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" md="4">
+        <v-form>
+          <header>Optional filter params:</header>
+          <v-text-field
+            v-model="formData.clientEntityId"
+            label="Client Entity Id"
+          />
+          <v-text-field v-model="formData.status" label="Status" />
+          <v-text-field v-model="formData.from" label="From" />
+          <v-text-field v-model="formData.to" label="To" />
+          <v-text-field v-model="formData.pageSize" label="PageSize" />
+          <v-text-field v-model="formData.pageBefore" label="PageBefore" />
+          <v-text-field v-model="formData.pageAfter" label="PageAfter" />
+          <v-btn
+            variant="flat"
+            class="mb-7"
+            color="primary"
+            :loading="loading"
+            @click.prevent="makeApiCall()"
+          >
+            Make api call
+          </v-btn>
+        </v-form>
+      </v-col>
+      <v-col cols="12" md="8">
+        <RequestInfo
+          :url="requestUrl"
+          :payload="payload"
+          :response="response"
+        />
+      </v-col>
+    </v-row>
+    <ErrorSheet
+      :error="error"
+      :show-error="showError"
+      @on-change="onErrorSheetClosed"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const store = useMainStore()
+const { $daaWithdrawalsApi } = useNuxtApp()
+
+const formData = reactive({
+  clientEntityId: '',
+  status: '',
+  from: '',
+  to: '',
+  pageSize: '',
+  pageBefore: '',
+  pageAfter: '',
+})
+
+const error = ref<any>({})
+const loading = ref(false)
+const showError = ref(false)
+
+const payload = computed(() => store.getRequestPayload)
+const response = computed(() => store.getRequestResponse)
+const requestUrl = computed(() => store.getRequestUrl)
+
+const onErrorSheetClosed = () => {
+  error.value = {}
+  showError.value = false
+}
+
+const makeApiCall = async () => {
+  loading.value = true
+  try {
+    await $daaWithdrawalsApi.getWithdrawals(
+      formData.clientEntityId,
+      formData.status,
+      formData.from,
+      formData.to,
+      formData.pageBefore,
+      formData.pageAfter,
+      formData.pageSize,
+    )
+  } catch (err) {
+    error.value = err
+    showError.value = true
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/plugins/daa/index.ts
+++ b/plugins/daa/index.ts
@@ -1,0 +1,51 @@
+import { daaInstance } from '@/lib/daa/client'
+import accountsApi from '@/lib/daa/accountsApi'
+import wiresApi from '@/lib/daa/wiresApi'
+import transfersApi from '@/lib/daa/transfersApi'
+import transactionsApi from '@/lib/daa/transactionsApi'
+import depositsApi from '@/lib/daa/depositsApi'
+import withdrawalsApi from '@/lib/daa/withdrawalsApi'
+import addressesApi from '@/lib/daa/addressesApi'
+
+export default defineNuxtPlugin(() => {
+  const { $pinia } = useNuxtApp()
+  const store = useMainStore($pinia)
+
+  daaInstance.interceptors.request.use(
+    function (config) {
+      store.clearRequestData()
+      store.setRequestUrl(`${config.baseURL}${config.url}`)
+      store.setRequestPayload(config.data)
+
+      if (store.bearerToken) {
+        config.headers.Authorization = `Bearer ${store.bearerToken}`
+      }
+      return config
+    },
+    function (error) {
+      return Promise.reject(error)
+    },
+  )
+
+  daaInstance.interceptors.response.use(
+    function (response) {
+      store.setResponse(response)
+      return response
+    },
+    function (error) {
+      return Promise.reject(error)
+    },
+  )
+
+  return {
+    provide: {
+      daaAccountsApi: accountsApi,
+      daaTransactionsApi: transactionsApi,
+      daaWiresApi: wiresApi,
+      daaTransfersApi: transfersApi,
+      daaDepositsApi: depositsApi,
+      daaWithdrawalsApi: withdrawalsApi,
+      daaAddressesApi: addressesApi,
+    },
+  }
+})

--- a/stores/main.ts
+++ b/stores/main.ts
@@ -14,12 +14,19 @@ export interface DelegateFundingEntry {
   funderSignature: string
 }
 
+export interface RiskSignals {
+  ipAddress: string
+  sessionId: string
+  deviceId: string
+}
+
 interface MainState {
   bearerToken: string
   walletApiKey: string
   entitySecret: string
   walletId: string
   funderWalletId: string
+  riskSignals: RiskSignals
   apiRequest: ApiRequest
   delegateFundingBatch: DelegateFundingEntry[]
 }
@@ -46,6 +53,11 @@ export const useMainStore = defineStore('main', {
       typeof window !== 'undefined'
         ? localStorage.getItem('funderWalletId') || ''
         : '',
+    riskSignals: {
+      ipAddress: '',
+      sessionId: '',
+      deviceId: '',
+    },
     apiRequest: {
       url: '',
       payload: {},
@@ -60,6 +72,7 @@ export const useMainStore = defineStore('main', {
     getEntitySecret: (state): string => state.entitySecret,
     getWalletId: (state): string => state.walletId,
     getFunderWalletId: (state): string => state.funderWalletId,
+    getRiskSignals: (state): RiskSignals => state.riskSignals,
     getRequestPayload: (state): any => state.apiRequest.payload,
     getRequestResponse: (state): any => state.apiRequest.response,
     getRequestUrl: (state): string => state.apiRequest.url,
@@ -101,6 +114,10 @@ export const useMainStore = defineStore('main', {
       if (typeof window !== 'undefined') {
         localStorage.setItem('funderWalletId', funderWalletId)
       }
+    },
+
+    setRiskSignals(riskSignals: RiskSignals) {
+      this.riskSignals = riskSignals
     },
 
     setRequestUrl(url: string) {


### PR DESCRIPTION
Add a new "Digital Asset Accounts" section targeting the DAA API surface (/v1/accounts, /v1/banks, /v1/addresses), separate from the legacy /v1/businessAccount/* endpoints.

Endpoints:
- Accounts: create, list, get by id
- Transfers: create (source + account/blockchain destination), list, get by id
- Transactions: list
- Withdrawals: create (source required), list, get by id
- Deposits: list
- Wires: create (clientEntityId + riskSignals), list, get by id, instructions (walletId required to target an explicit wallet)
- Deposit and recipient addresses: create, list, delete

DAA params wired in: clientEntityId, source ({type:"account", id}), and riskSignals. Adds a Risk Signals section to Settings (required for DAA wire creation) and a US-account prefill for the DAA wire form.