### PR TITLE
fix: attach risk signals to all DAA endpoints that require them

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -303,7 +303,8 @@
                 />
                 <p class="subtitle-2 font-weight-light">
                   Risk signals for the end user initiating the request. Required
-                  when creating wire accounts.
+                  when creating wire accounts, withdrawals, transfers, or
+                  recipient addresses.
                 </p>
               </v-form>
             </v-expansion-panel-text>

--- a/lib/daa/addressesApi.ts
+++ b/lib/daa/addressesApi.ts
@@ -1,4 +1,5 @@
 import { daaInstance, nullIfEmpty } from './client'
+import type { RiskSignals } from './wiresApi'
 
 export interface CreateDepositAddressPayload {
   idempotencyKey: string
@@ -15,6 +16,7 @@ export interface CreateRecipientAddressPayload {
   currency?: string
   description: string
   clientEntityId?: string
+  riskSignals: RiskSignals
 }
 
 const DEPOSIT_PATH = '/v1/accounts/addresses/deposit'

--- a/lib/daa/transfersApi.ts
+++ b/lib/daa/transfersApi.ts
@@ -1,4 +1,5 @@
 import { daaInstance, nullIfEmpty } from './client'
+import type { RiskSignals } from './wiresApi'
 
 export interface BlockchainDestination {
   type: string
@@ -25,6 +26,7 @@ export interface CreateTransferPayload {
   destination: BlockchainDestination | AccountDestination
   amount: Amount
   source?: Source
+  riskSignals: RiskSignals
 }
 
 const TRANSFERS_PATH = '/v1/accounts/transfers'

--- a/lib/daa/withdrawalsApi.ts
+++ b/lib/daa/withdrawalsApi.ts
@@ -1,4 +1,5 @@
 import { daaInstance, nullIfEmpty } from './client'
+import type { RiskSignals } from './wiresApi'
 
 export interface CreateWithdrawalPayload {
   idempotencyKey: string
@@ -17,6 +18,7 @@ export interface CreateWithdrawalPayload {
   toAmount?: {
     currency: string
   }
+  riskSignals: RiskSignals
 }
 
 const WITHDRAWALS_PATH = '/v1/accounts/withdrawals'

--- a/pages/debug/daa/addresses/recipient/create.vue
+++ b/pages/debug/daa/addresses/recipient/create.vue
@@ -96,6 +96,7 @@ const makeApiCall = async () => {
     currency,
     description,
     clientEntityId,
+    riskSignals: { ...store.getRiskSignals },
   }
 
   if (hasAddressTagSupport(chain)) {

--- a/pages/debug/daa/transfers/create.vue
+++ b/pages/debug/daa/transfers/create.vue
@@ -99,6 +99,7 @@ const makeApiCall = async () => {
     ...(formData.sourceId && {
       source: { type: 'account', id: formData.sourceId },
     }),
+    riskSignals: { ...store.getRiskSignals },
   }
 
   try {

--- a/pages/debug/daa/withdrawals/create.vue
+++ b/pages/debug/daa/withdrawals/create.vue
@@ -110,6 +110,7 @@ const makeApiCall = async () => {
     ...(formData.toCurrency && {
       toAmount: { currency: formData.toCurrency },
     }),
+    riskSignals: { ...store.getRiskSignals },
   }
   try {
     await $daaWithdrawalsApi.createWithdrawal(payloadData)


### PR DESCRIPTION
## Summary
- Digital Asset Accounts withdrawal, transfer, and recipient-address creation requests were missing `riskSignals`, so the API rejects them with "Risk signals required." Wire account creation already attached them correctly.
- Per the `accounts.yaml` OpenAPI spec (`components.schemas`), `riskSignals` is required on exactly four request schemas: `AccountWireCreationRequest`, `AccountWithdrawalCreationRequest`, `AccountTransferCreationRequest`, and `AccountRecipientAddressCreationRequest`. Account creation, ACH, and deposit-address creation do not require it.
- Mirrors the existing wire-account pattern: pull `riskSignals` from the global settings-drawer store (`store.getRiskSignals`) into each payload.
- Updated the settings-drawer hint text, which previously only mentioned wire accounts, to list all four endpoints that require risk signals.

## Test plan
- [x] Verified against the published OpenAPI spec at `https://developers.circle.com/openapi/accounts.yaml` which endpoints require `riskSignals`
- [x] Ran the app locally against `api-smokebox.circle.com` and confirmed each payload now includes `riskSignals`
- [ ] Manually create a withdrawal, transfer, and recipient address against smokebox with risk signals filled in via the settings drawer and confirm the requests succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)